### PR TITLE
Fix VR host: empty world, missing jobs, and control-grab failures

### DIFF
--- a/Multiplayer/Components/Networking/NetworkLifecycle.cs
+++ b/Multiplayer/Components/Networking/NetworkLifecycle.cs
@@ -168,6 +168,10 @@ public class NetworkLifecycle : SingletonBehaviour<NetworkLifecycle>
         var clientAPI = new ClientAPIProvider(client);
         MultiplayerAPI.RegisterClient(clientAPI);
 
+        // Start streaming the local player's position. Driven here (not from the player controller)
+        // so it works in VR, where CustomFirstPersonController is never instantiated.
+        Patches.Player.CustomFirstPersonControllerPatch.SubscribePositionSync();
+
         OnSettingsUpdated(Multiplayer.Settings); // Show stats if enabled
     }
 
@@ -240,6 +244,7 @@ public class NetworkLifecycle : SingletonBehaviour<NetworkLifecycle>
 
         if (Client != null)
         {
+            Patches.Player.CustomFirstPersonControllerPatch.UnsubscribePositionSync();
             Client?.Stop();
             MultiplayerAPI.ClearClient();
             Client = null;

--- a/Multiplayer/Components/Networking/Train/NetworkedTrainCar.cs
+++ b/Multiplayer/Components/Networking/Train/NetworkedTrainCar.cs
@@ -1007,9 +1007,15 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
         {
             if (currentAuth == null)
             {
-                if ((player.WorldPosition - transform.position).sqrMagnitude > CarLengthSq)
+                // The host is the authoritative server and fully trusted. Its own networked position can
+                // lag or be wrong (notably in VR, where PlayerTransform doesn't track the same as desktop),
+                // so distance-denying the host would strip controls out of its hand the moment it grabs
+                // them. Desktop hides this because scroll/click interactions don't need a sustained hold;
+                // VR exposes it as a "grab then instantly release". Never distance-deny the host.
+                float sqrDist = (player.WorldPosition - transform.position).sqrMagnitude;
+                if (sqrDist > CarLengthSq && !NetworkLifecycle.Instance.IsHost(player))
                 {
-                    NetworkLifecycle.Instance.Server.LogWarning($"Player \"{player.Username}\" attempted to gain authority for a control on car {CurrentID}, but they are too far away!");
+                    NetworkLifecycle.Instance.Server.LogWarning($"Player \"{player.Username}\" attempted to gain authority for a control on car {CurrentID}, but they are too far away! (sqrDist {sqrDist} > {CarLengthSq})");
                     NetworkLifecycle.Instance.Server.SendTrainControlAuthorityUpdate(NetId, portNetId, ControlAuthorityState.Denied, player);
                     NetworkLifecycle.Instance.Server.SendTrainControlAuthorityUpdate(NetId, portNetId, ControlAuthorityState.Released, player);
                     return;

--- a/Multiplayer/Components/Networking/World/NetworkedItemManager.cs
+++ b/Multiplayer/Components/Networking/World/NetworkedItemManager.cs
@@ -197,16 +197,18 @@ public class NetworkedItemManager : SingletonBehaviour<NetworkedItemManager>
                 }
             }
 
-            // Remove items that are no longer nearby
-            for (int i = 0; i < player.NearbyItems.Count; i++)
-            {
-                var kvp = player.NearbyItems.ElementAt(i);
+            // Remove items that are no longer nearby. Collect first, then remove: mutating the
+            // dictionary while walking it by index (ElementAt) both skips entries as the collection
+            // shifts and is O(n^2).
+            var noLongerNearby = player.NearbyItems
+                .Where(kvp => currentTime - kvp.Value > NEARBY_REMOVAL_DELAY)
+                .Select(kvp => kvp.Key)
+                .ToList();
 
-                if (currentTime - kvp.Value > NEARBY_REMOVAL_DELAY)
-                {
-                    //NetworkLifecycle.Instance.Server.LogDebug(() => $"UpdatePlayerItemLists() Removing for player: {player?.Username}, Nearby Item: {kvp.Key?.NetId}, {kvp.Key?.name}");
-                    player.NearbyItems.Remove(kvp.Key);
-                }
+            foreach (var item in noLongerNearby)
+            {
+                //NetworkLifecycle.Instance.Server.LogDebug(() => $"UpdatePlayerItemLists() Removing for player: {player?.Username}, Nearby Item: {item?.NetId}, {item?.name}");
+                player.NearbyItems.Remove(item);
             }
         }
     }

--- a/Multiplayer/Components/Networking/World/NetworkedJunction.cs
+++ b/Multiplayer/Components/Networking/World/NetworkedJunction.cs
@@ -69,7 +69,12 @@ public class NetworkedJunction : IdMonoBehaviour<ushort, NetworkedJunction>
 
     private void Junction_Switched(Junction.SwitchMode switchMode, int branch)
     {
-        if (NetworkLifecycle.Instance.IsProcessingPacket || !initialised)
+        // The host is authoritative and never receives the ClientboundRailwayStatePacket that
+        // sets 'initialised' on clients, so it must not depend on the Awake-time IsHost() snapshot.
+        // If this junction awoke before the server started (e.g. when loading a save), that snapshot
+        // is false and the host would be permanently unable to send switch changes. Re-checking
+        // IsHost() live here avoids that lockout while still suppressing client echo during load.
+        if (NetworkLifecycle.Instance.IsProcessingPacket || (!initialised && !NetworkLifecycle.Instance.IsHost()))
             return;
 
         NetworkLifecycle.Instance.Client.SendJunctionSwitched(NetId, (byte)branch, switchMode);

--- a/Multiplayer/Components/Networking/World/NetworkedTurntable.cs
+++ b/Multiplayer/Components/Networking/World/NetworkedTurntable.cs
@@ -69,7 +69,10 @@ public class NetworkedTurntable : IdMonoBehaviour<byte, NetworkedTurntable>
 
     private void OnTick(uint tick)
     {
-        if (UnloadWatcher.isUnloading || !initialised || Mathf.Approximately(lastYRotation, TurntableRailTrack.targetYRotation))
+        // See NetworkedJunction.Junction_Switched: the host never receives the railway-state packet
+        // that sets 'initialised', so check IsHost() live to avoid a lockout when this turntable
+        // awoke before the server started (e.g. when loading a save).
+        if (UnloadWatcher.isUnloading || (!initialised && !NetworkLifecycle.Instance.IsHost()) || Mathf.Approximately(lastYRotation, TurntableRailTrack.targetYRotation))
             return;
 
         lastYRotation = TurntableRailTrack.targetYRotation;

--- a/Multiplayer/Networking/Data/ServerPlayer.cs
+++ b/Multiplayer/Networking/Data/ServerPlayer.cs
@@ -90,6 +90,7 @@ public class ServerPlayer : IDisposable
 
     private Vector3 _lastWorldPos = Vector3.zero;
     private Vector3 _lastAbsoluteWorldPosition = Vector3.zero;
+    private float _lastWorldRotationY;
 
     public ServerPlayer(ITransportPeer peer, string username, string originalUsername, Guid guid)
     {
@@ -112,20 +113,27 @@ public class ServerPlayer : IDisposable
             Vector3 pos;
             try
             {
-                if (CarId == 0 || !NetworkedTrainCar.TryGet(CarId, out NetworkedTrainCar car))
+                if (CarId == 0)
                 {
-                    if (CarId != 0)
-                        Multiplayer.LogDebug(() => $"AbsoluteWorldPosition() noID {Username}: CarId: {CarId}");
-
+                    // Off-car: RawPosition is already a world-absolute position.
                     pos = RawPosition;
+                    _lastAbsoluteWorldPosition = pos;
+                }
+                else if (NetworkedTrainCar.TryGet(CarId, out NetworkedTrainCar car))
+                {
+                    pos = car.transform.TransformPoint(RawPosition) - WorldMover.currentMove;
+                    _lastAbsoluteWorldPosition = pos;
                 }
                 else
                 {
-                    //Multiplayer.LogDebug(() => $"AbsoluteWorldPosition() hasID {Username}: CarId: {CarId}");
-                    pos = car.transform.TransformPoint(RawPosition) - WorldMover.currentMove; ;
+                    // On a car we can't resolve yet (NetId assignment races with load, or the car just
+                    // despawned). RawPosition is car-LOCAL here, so it can't be turned into a world
+                    // position — return the last known-good value instead of interpreting a local
+                    // offset as a world coordinate (which would place the player kilometres away and
+                    // break distance/authority/reach checks).
+                    Multiplayer.LogDebug(() => $"AbsoluteWorldPosition() noID {Username}: CarId: {CarId}");
+                    pos = _lastAbsoluteWorldPosition;
                 }
-
-                _lastAbsoluteWorldPosition = pos;
             }
             catch (Exception e)
             {
@@ -147,20 +155,25 @@ public class ServerPlayer : IDisposable
             Vector3 pos;
             try
             {
-                if (CarId == 0 || !NetworkedTrainCar.TryGet(CarId, out NetworkedTrainCar car))
+                if (CarId == 0)
                 {
-                    if (CarId != 0)
-                        Multiplayer.LogDebug(() => $"WorldPosition() noID {Username}: CarId: {CarId}");
-
+                    // Off-car: RawPosition is a world-absolute position; shift it into the moved frame.
                     pos = RawPosition + WorldMover.currentMove;
+                    _lastWorldPos = pos;
+                }
+                else if (NetworkedTrainCar.TryGet(CarId, out NetworkedTrainCar car))
+                {
+                    pos = car.transform.TransformPoint(RawPosition);
+                    _lastWorldPos = pos;
                 }
                 else
                 {
-                    //Multiplayer.LogDebug(() => $"WorldPosition() hasID {Username}: CarId: {CarId}");
-                    pos = car.transform.TransformPoint(RawPosition);
+                    // On a car we can't resolve yet (NetId assignment races with load, or the car just
+                    // despawned). RawPosition is car-LOCAL here, so return the last known-good value
+                    // rather than treating a local offset as a world coordinate (see AbsoluteWorldPosition).
+                    Multiplayer.LogDebug(() => $"WorldPosition() noID {Username}: CarId: {CarId}");
+                    pos = _lastWorldPos;
                 }
-
-                _lastWorldPos = pos;
             }
             catch (Exception e)
             {
@@ -175,9 +188,32 @@ public class ServerPlayer : IDisposable
         }
     }
 
-    public float WorldRotationY => CarId == 0 || !NetworkedTrainCar.TryGet(CarId, out NetworkedTrainCar car)
-        ? RawRotationY
-        : (Quaternion.Euler(0, RawRotationY, 0) * car.transform.rotation).eulerAngles.y;
+    public float WorldRotationY
+    {
+        get
+        {
+            float rot;
+            if (CarId == 0)
+            {
+                // Off-car: RawRotationY is already a world-space heading.
+                rot = RawRotationY;
+                _lastWorldRotationY = rot;
+            }
+            else if (NetworkedTrainCar.TryGet(CarId, out NetworkedTrainCar car))
+            {
+                rot = (Quaternion.Euler(0, RawRotationY, 0) * car.transform.rotation).eulerAngles.y;
+                _lastWorldRotationY = rot;
+            }
+            else
+            {
+                // On a car we can't resolve yet (NetId race / just despawned). RawRotationY is car-LOCAL
+                // here, so return the last known-good heading rather than a local rotation as world.
+                rot = _lastWorldRotationY;
+            }
+
+            return rot;
+        }
+    }
     #endregion
 
     #region Item Ownership

--- a/Multiplayer/Patches/Player/CustomFirstPersonControllerPatch.cs
+++ b/Multiplayer/Patches/Player/CustomFirstPersonControllerPatch.cs
@@ -62,23 +62,31 @@ public static class CustomFirstPersonControllerPatch
             isOnCar = car != null;
         }
 
-        Vector3 position = isOnCar ? PlayerManager.PlayerTransform.localPosition : PlayerManager.PlayerTransform.GetWorldAbsolutePosition();
+        // Only report the player as "on car" once we have a valid NetId for that car. Right after a
+        // save load the car's NetworkedTrainCar.NetId may not be assigned yet; if we sent the car-LOCAL
+        // position together with CarId 0, the server would interpret that small local offset as a
+        // world-absolute position and place the player kilometres away. That breaks control-authority
+        // proximity checks, so cab controls get grabbed then instantly force-released (~10ms "grip").
+        // Falling back to a world-absolute position + CarId 0 keeps position, CarId and the on-car flag
+        // consistent, and self-corrects on the next tick once the NetId is assigned.
+        ushort carNetID = isOnCar ? car.GetNetId() : (ushort)0;
+        bool onCarNetworked = isOnCar && carNetID != 0;
+
+        Vector3 position = onCarNetworked ? PlayerManager.PlayerTransform.localPosition : PlayerManager.PlayerTransform.GetWorldAbsolutePosition();
         float rotationY = PlayerManager.PlayerCamera.transform.eulerAngles.y;
 
-        ushort carNetID = isOnCar ? car.GetNetId() : (ushort)0;
-
-        bool positionOrRotationChanged = lastOnCar != isOnCar || (isOnCar && (lastCarNetId != carNetID)) || Vector3.Distance(lastPosition, position) > 0 || Math.Abs(lastRotationY - rotationY) > 0.2f;//ROTATION_THRESHOLD;
+        bool positionOrRotationChanged = lastOnCar != onCarNetworked || (onCarNetworked && (lastCarNetId != carNetID)) || Vector3.Distance(lastPosition, position) > 0 || Math.Abs(lastRotationY - rotationY) > 0.2f;//ROTATION_THRESHOLD;
 
         if (!positionOrRotationChanged && sentFinalPosition)
             return;
 
-        lastOnCar = isOnCar;
+        lastOnCar = onCarNetworked;
         lastCarNetId = carNetID;
         lastPosition = position;
         lastRotationY = rotationY;
         sentFinalPosition = !positionOrRotationChanged;
 
-        NetworkLifecycle.Instance.Client.SendPlayerPosition(lastPosition, PlayerManager.PlayerTransform.InverseTransformDirection(fps.m_MoveDir), lastRotationY, carNetID, isJumping, isOnCar, isJumping || sentFinalPosition);
+        NetworkLifecycle.Instance.Client.SendPlayerPosition(lastPosition, PlayerManager.PlayerTransform.InverseTransformDirection(fps.m_MoveDir), lastRotationY, carNetID, isJumping, onCarNetworked, isJumping || sentFinalPosition);
         isJumping = false;
     }
 

--- a/Multiplayer/Patches/Player/CustomFirstPersonControllerPatch.cs
+++ b/Multiplayer/Patches/Player/CustomFirstPersonControllerPatch.cs
@@ -1,3 +1,4 @@
+using DV.Player;
 using HarmonyLib;
 using Multiplayer.Components.Networking;
 using Multiplayer.Utils;
@@ -11,6 +12,8 @@ public static class CustomFirstPersonControllerPatch
 {
     private const float ROTATION_THRESHOLD = 0.001f;
 
+    // The desktop controller. Null in VR (DV doesn't instantiate CustomFirstPersonController there),
+    // so it's only used as an optional source for the exact movement direction.
     private static CustomFirstPersonController fps;
 
     private static bool lastOnCar;
@@ -23,15 +26,43 @@ public static class CustomFirstPersonControllerPatch
     private static bool isOnCar;
     private static TrainCar car;
 
+    private static bool subscribed;
+
+    // Position sync is driven by the network client lifecycle, NOT by the player controller.
+    // CustomFirstPersonController.Awake only fires on desktop; in VR it never runs, so hooking it
+    // meant the host's position was never sent and stayed at (0,0,0) on the server — breaking every
+    // proximity-gated system (station loco spawning, job generation, control authority). Subscribing
+    // from StartClient (both modes) fixes that.
+    internal static void SubscribePositionSync()
+    {
+        if (subscribed)
+            return;
+        subscribed = true;
+
+        lastOnCar = false;
+        lastCarNetId = 0;
+        lastPosition = Vector3.zero;
+        lastRotationY = 0f;
+        sentFinalPosition = false;
+        isJumping = false;
+
+        NetworkLifecycle.Instance.OnTick += OnTick;
+    }
+
+    internal static void UnsubscribePositionSync()
+    {
+        if (!subscribed)
+            return;
+        subscribed = false;
+        NetworkLifecycle.Instance.OnTick -= OnTick;
+    }
+
     [HarmonyPatch(nameof(CustomFirstPersonController.Awake))]
     [HarmonyPostfix]
     private static void CharacterMovement(CustomFirstPersonController __instance)
     {
+        // Desktop only: capture the controller so we can read its precise move direction.
         fps = __instance;
-        isOnCar = PlayerManager.Car != null;
-        car = PlayerManager.Car;
-        NetworkLifecycle.Instance.OnTick += OnTick;
-        PlayerManager.CarChanged += OnCarChanged;
     }
 
     [HarmonyPostfix]
@@ -41,26 +72,26 @@ public static class CustomFirstPersonControllerPatch
         if (UnloadWatcher.isQuitting)
             return;
 
-        NetworkLifecycle.Instance.OnTick -= OnTick;
-        PlayerManager.CarChanged -= OnCarChanged;
-    }
-
-    private static void OnCarChanged(TrainCar trainCar)
-    {
-        isOnCar = trainCar != null;
-        car = trainCar;
+        fps = null;
     }
 
     private static void OnTick(uint tick)
     {
-        if(UnloadWatcher.isUnloading)
+        if (UnloadWatcher.isUnloading)
             return;
 
-        if (isOnCar && car == null)
-        {
-            car = PlayerManager.Car;
-            isOnCar = car != null;
-        }
+        // Guard for readiness: on the host StartClient runs before the world/player exist, and this
+        // must also work in VR where there is no CustomFirstPersonController.
+        if (NetworkLifecycle.Instance.Client == null)
+            return;
+        Transform playerTransform = PlayerManager.PlayerTransform;
+        if (playerTransform == null || PlayerManager.PlayerCamera == null)
+            return;
+
+        // Poll the current car directly (no CarChanged event dependency, so it works regardless of
+        // which controller is active).
+        car = PlayerManager.Car;
+        isOnCar = car != null;
 
         // Only report the player as "on car" once we have a valid NetId for that car. Right after a
         // save load the car's NetworkedTrainCar.NetId may not be assigned yet; if we sent the car-LOCAL
@@ -72,7 +103,7 @@ public static class CustomFirstPersonControllerPatch
         ushort carNetID = isOnCar ? car.GetNetId() : (ushort)0;
         bool onCarNetworked = isOnCar && carNetID != 0;
 
-        Vector3 position = onCarNetworked ? PlayerManager.PlayerTransform.localPosition : PlayerManager.PlayerTransform.GetWorldAbsolutePosition();
+        Vector3 position = onCarNetworked ? playerTransform.localPosition : playerTransform.GetWorldAbsolutePosition();
         float rotationY = PlayerManager.PlayerCamera.transform.eulerAngles.y;
 
         bool positionOrRotationChanged = lastOnCar != onCarNetworked || (onCarNetworked && (lastCarNetId != carNetID)) || Vector3.Distance(lastPosition, position) > 0 || Math.Abs(lastRotationY - rotationY) > 0.2f;//ROTATION_THRESHOLD;
@@ -86,7 +117,11 @@ public static class CustomFirstPersonControllerPatch
         lastRotationY = rotationY;
         sentFinalPosition = !positionOrRotationChanged;
 
-        NetworkLifecycle.Instance.Client.SendPlayerPosition(lastPosition, PlayerManager.PlayerTransform.InverseTransformDirection(fps.m_MoveDir), lastRotationY, carNetID, isJumping, onCarNetworked, isJumping || sentFinalPosition);
+        // Move direction is only used to animate the remote avatar's walk; the desktop controller
+        // exposes it exactly, in VR we don't have it so send zero (avatar still lerps toward position).
+        Vector3 moveDir = fps != null ? playerTransform.InverseTransformDirection(fps.m_MoveDir) : Vector3.zero;
+
+        NetworkLifecycle.Instance.Client.SendPlayerPosition(lastPosition, moveDir, lastRotationY, carNetID, isJumping, onCarNetworked, isJumping || sentFinalPosition);
         isJumping = false;
     }
 


### PR DESCRIPTION
## Summary

Fixes a family of host-side bugs that traced back to a single root cause: **the local player's position was only streamed from `CustomFirstPersonController`, which DV never instantiates in VR.** As a result a VR host never sent a position and the server pinned it at `(0,0,0)`, breaking every proximity-gated system for that player.

```
- Fixed issue where VR player position was not being updated in the server
- Fixed issue where player's hand sometimes stopped gripping a control
- Spawning into a save file now works correctly
```

Fixes #136, #124

## Symptoms this resolves (all VR host)
- New games spawn **no station locomotives and no cars**.
- **Jobs/quests never generate.**
- Grabbing any held control (brake hoses, cab levers, instruments) **latches then instantly releases** (authority denied "too far away" — only visible in VR because grabs are held rather than clicked).
- Desktop was unaffected because that controller runs there.

## Changes

**Stream host position in VR**
- Drive position streaming from the network client lifecycle (`NetworkLifecycle.StartClient`/`Stop`) instead of the desktop-only player controller, so it runs in both VR and desktop.
- `OnTick` now polls `PlayerManager` directly, guards against pre-world/null state, and tolerates a missing controller (move direction falls back to zero in VR).
- Never distance-deny the **host** for train control authority — it's the authoritative server and its networked position can lag, so it must not be able to deny itself control of things it's holding.

**Host/load authority and position races**
- `NetworkedJunction` / `NetworkedTurntable`: the host gated sends on an Awake-time `IsHost()` snapshot and is excluded from the railway-state sync packet, so after loading a save it could never send switch/rotation changes. Now re-checks `IsHost()` live.
- `ServerPlayer.WorldPosition` / `AbsoluteWorldPosition` / `WorldRotationY`: return last-known-good instead of garbage when a car can't be resolved (protects authority, culling, item reach, paint/rerail distance).
- `NetworkedItemManager`: fixed a nearby-items prune that mutated a dictionary while iterating it by index (skipped entries, O(n^2)).

## Testing
Verified in VR by the reporter: fresh new game (tutorial skipped) now spawns trains and jobs; controls can be grabbed and held; state persists correctly across save → quit → reload. Desktop behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code) - Edited by me, the human