### PR TITLE
Authenticate player identity against Steam; stable IPlayer.UniqueId + permission-check hook

### DIFF
--- a/Multiplayer/API/APIProvider.cs
+++ b/Multiplayer/API/APIProvider.cs
@@ -12,7 +12,7 @@ namespace Multiplayer.API;
 
 public class APIProvider : IMultiplayerAPI
 {
-    internal const string BUILT_AGAINST_API_VERSION = "1.1.0.0";
+    internal const string BUILT_AGAINST_API_VERSION = "1.2.0.0";
 
     public string SupportedApiVersion => BUILT_AGAINST_API_VERSION;
 

--- a/Multiplayer/API/APIProvider.cs
+++ b/Multiplayer/API/APIProvider.cs
@@ -12,7 +12,7 @@ namespace Multiplayer.API;
 
 public class APIProvider : IMultiplayerAPI
 {
-    internal const string BUILT_AGAINST_API_VERSION = "1.2.0.0";
+    internal const string BUILT_AGAINST_API_VERSION = "1.3.0.0";
 
     public string SupportedApiVersion => BUILT_AGAINST_API_VERSION;
 

--- a/Multiplayer/API/ClientPlayerWrapper.cs
+++ b/Multiplayer/API/ClientPlayerWrapper.cs
@@ -18,6 +18,7 @@ public class ClientPlayerWrapper : IPlayer
     public byte PlayerId => _networkedPlayer.PlayerId;
     // Clients don't track remote players' stable identity; only the server does (see IPlayer.UniqueId).
     public System.Guid UniqueId => System.Guid.Empty;
+    public bool IsAuthenticated => false;
     public string Username
     {
         get => _networkedPlayer.Username;

--- a/Multiplayer/API/ClientPlayerWrapper.cs
+++ b/Multiplayer/API/ClientPlayerWrapper.cs
@@ -16,6 +16,8 @@ public class ClientPlayerWrapper : IPlayer
     }
 
     public byte PlayerId => _networkedPlayer.PlayerId;
+    // Clients don't track remote players' stable identity; only the server does (see IPlayer.UniqueId).
+    public System.Guid UniqueId => System.Guid.Empty;
     public string Username
     {
         get => _networkedPlayer.Username;

--- a/Multiplayer/API/ServerAPIProvider.cs
+++ b/Multiplayer/API/ServerAPIProvider.cs
@@ -103,6 +103,18 @@ public class ServerAPIProvider : IServer
     }
     #endregion
 
+    #region Permissions
+    public void RegisterPermissionCheck(PermissionCheckDelegate check)
+    {
+        server.RegisterPermissionCheck(check);
+    }
+
+    public void UnregisterPermissionCheck(PermissionCheckDelegate check)
+    {
+        server.UnregisterPermissionCheck(check);
+    }
+    #endregion
+
     #region Chat
     public void SendServerChatMessage(string message, IPlayer excludePlayer = null)
     {

--- a/Multiplayer/API/ServerPlayerWrapper.cs
+++ b/Multiplayer/API/ServerPlayerWrapper.cs
@@ -22,6 +22,9 @@ public class ServerPlayerWrapper : IPlayer
 
     public System.Guid UniqueId => _serverPlayer.Guid;
 
+    // A verified platform account is the only thing that makes UniqueId a proof rather than a claim.
+    public bool IsAuthenticated => _serverPlayer.SteamId != 0;
+
     public string Username
     {
         get => _serverPlayer.Username;

--- a/Multiplayer/API/ServerPlayerWrapper.cs
+++ b/Multiplayer/API/ServerPlayerWrapper.cs
@@ -20,6 +20,8 @@ public class ServerPlayerWrapper : IPlayer
 
     public byte PlayerId => _serverPlayer.PlayerId;
 
+    public System.Guid UniqueId => _serverPlayer.Guid;
+
     public string Username
     {
         get => _serverPlayer.Username;

--- a/Multiplayer/Components/Networking/Train/NetworkedTrainCar.cs
+++ b/Multiplayer/Components/Networking/Train/NetworkedTrainCar.cs
@@ -12,6 +12,7 @@ using DV.ThingTypes;
 using JetBrains.Annotations;
 using LocoSim.Definitions;
 using LocoSim.Implementations;
+using MPAPI.Types;
 using Multiplayer.Components.Networking.Player;
 using Multiplayer.Networking.Data;
 using Multiplayer.Networking.Data.Train;
@@ -1010,6 +1011,15 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
                 if ((player.WorldPosition - transform.position).sqrMagnitude > CarLengthSq)
                 {
                     NetworkLifecycle.Instance.Server.LogWarning($"Player \"{player.Username}\" attempted to gain authority for a control on car {CurrentID}, but they are too far away!");
+                    NetworkLifecycle.Instance.Server.SendTrainControlAuthorityUpdate(NetId, portNetId, ControlAuthorityState.Denied, player);
+                    NetworkLifecycle.Instance.Server.SendTrainControlAuthorityUpdate(NetId, portNetId, ControlAuthorityState.Released, player);
+                    return;
+                }
+
+                // Consult any per-player permission checks registered by external mods before granting.
+                if (!NetworkLifecycle.Instance.Server.CheckPermission(player, PermissionAction.TrainControlAuthority, TrainCar))
+                {
+                    NetworkLifecycle.Instance.Server.LogWarning($"Player \"{player.Username}\" was denied authority for a control on car {CurrentID} by a permission check.");
                     NetworkLifecycle.Instance.Server.SendTrainControlAuthorityUpdate(NetId, portNetId, ControlAuthorityState.Denied, player);
                     NetworkLifecycle.Instance.Server.SendTrainControlAuthorityUpdate(NetId, portNetId, ControlAuthorityState.Released, player);
                     return;

--- a/Multiplayer/Locale.cs
+++ b/Multiplayer/Locale.cs
@@ -173,6 +173,15 @@ public static class Locale
     public static string DISCONN_REASON__FULL_SERVER => Get(DISCONN_REASON__FULL_SERVER_KEY);
     public const string DISCONN_REASON__FULL_SERVER_KEY = $"{PREFIX_DISCONN_REASON}/full_server";
 
+    public static string DISCONN_REASON__NOT_AUTHENTICATED => Get(DISCONN_REASON__NOT_AUTHENTICATED_KEY);
+    public const string DISCONN_REASON__NOT_AUTHENTICATED_KEY = $"{PREFIX_DISCONN_REASON}/not_authenticated";
+
+    public static string DISCONN_REASON__ALREADY_CONNECTED => Get(DISCONN_REASON__ALREADY_CONNECTED_KEY);
+    public const string DISCONN_REASON__ALREADY_CONNECTED_KEY = $"{PREFIX_DISCONN_REASON}/already_connected";
+
+    public static string DISCONN_REASON__AUTH_UNAVAILABLE => Get(DISCONN_REASON__AUTH_UNAVAILABLE_KEY);
+    public const string DISCONN_REASON__AUTH_UNAVAILABLE_KEY = $"{PREFIX_DISCONN_REASON}/auth_unavailable";
+
     public static string DISCONN_REASON__MODS => Get(DISCONN_REASON__MODS_KEY);
     public const string DISCONN_REASON__MODS_KEY = $"{PREFIX_DISCONN_REASON}/mods";
 

--- a/Multiplayer/Networking/Auth/ClientAuthTicket.cs
+++ b/Multiplayer/Networking/Auth/ClientAuthTicket.cs
@@ -1,0 +1,53 @@
+using DV.Platform.Steam;
+using Steamworks;
+
+namespace Multiplayer.Networking.Auth;
+
+/// <summary>
+///     Holds the local player's platform authentication ticket for the lifetime of a connection.
+/// </summary>
+/// <remarks>
+///     The ticket is minted by Steam for this account and this application. It is not secret — it travels
+///     over the wire in the login packet — but it cannot be produced for an account the caller does not
+///     own, and the server verifies it against Steam's backend rather than taking the client's word.
+///     <para>
+///         Tickets must be cancelled when the connection ends, otherwise the session leaks and subsequent
+///         tickets can be rejected as already in use.
+///     </para>
+/// </remarks>
+internal static class ClientAuthTicket
+{
+    private static AuthTicket ticket;
+
+    public static bool IsAvailable => DVSteamworks.Success && SteamClient.IsValid;
+
+    /// <summary>Mints a fresh ticket, replacing any ticket still held.</summary>
+    public static bool TryAcquire(out byte[] data, out ulong steamId)
+    {
+        data = null;
+        steamId = 0;
+
+        if (!IsAvailable)
+            return false;
+
+        Release();
+
+        ticket = SteamUser.GetAuthSessionTicket(default);
+        if (ticket?.Data == null || ticket.Data.Length == 0)
+        {
+            Multiplayer.LogWarning("Steam returned an empty authentication ticket");
+            Release();
+            return false;
+        }
+
+        data = ticket.Data;
+        steamId = SteamClient.SteamId.Value;
+        return true;
+    }
+
+    public static void Release()
+    {
+        ticket?.Cancel();
+        ticket = null;
+    }
+}

--- a/Multiplayer/Networking/Auth/PlayerIdentity.cs
+++ b/Multiplayer/Networking/Auth/PlayerIdentity.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Multiplayer.Networking.Auth;
+
+/// <summary>
+///     Derives a player's stable identity from an authenticated platform account id.
+/// </summary>
+/// <remarks>
+///     A player's identity must be a pure function of a credential they cannot choose. If the client
+///     picks the value, it is an assertion rather than a proof, and any client can assert any identity.
+///     <para>
+///         This maps an account id to an RFC 4122 name-based (version 5) UUID. The mapping is stable, so
+///         the same account yields the same <see cref="Guid"/> on every server and across reinstalls,
+///         but it cannot be claimed without first proving ownership of the account.
+///     </para>
+/// </remarks>
+internal static class PlayerIdentity
+{
+    /// <summary>
+    ///     Namespace for the generated UUIDs. Changing this value re-keys every stored player, orphaning
+    ///     their save data.
+    /// </summary>
+    private static readonly Guid Namespace = new("f0c4b0f4-3c5a-4a7c-9d2b-4a2f1f7f4b21");
+
+    public static Guid FromSteamId(ulong steamId)
+    {
+        return NameBased($"steam:{steamId}");
+    }
+
+    private static Guid NameBased(string name)
+    {
+        byte[] namespaceBytes = Namespace.ToByteArray();
+        SwapEndianness(namespaceBytes); // RFC 4122 hashes the namespace big-endian; Guid.ToByteArray() is little-endian.
+
+        byte[] hash;
+        using (SHA1 sha1 = SHA1.Create())
+        {
+            byte[] nameBytes = Encoding.UTF8.GetBytes(name);
+            sha1.TransformBlock(namespaceBytes, 0, namespaceBytes.Length, null, 0);
+            sha1.TransformFinalBlock(nameBytes, 0, nameBytes.Length);
+            hash = sha1.Hash;
+        }
+
+        byte[] result = new byte[16];
+        Array.Copy(hash, result, 16);
+
+        result[6] = (byte)((result[6] & 0x0F) | 0x50); // version 5
+        result[8] = (byte)((result[8] & 0x3F) | 0x80); // RFC 4122 variant
+
+        SwapEndianness(result);
+        return new Guid(result);
+    }
+
+    private static void SwapEndianness(byte[] guid)
+    {
+        Swap(guid, 0, 3);
+        Swap(guid, 1, 2);
+        Swap(guid, 4, 5);
+        Swap(guid, 6, 7);
+    }
+
+    private static void Swap(byte[] bytes, int left, int right)
+    {
+        (bytes[left], bytes[right]) = (bytes[right], bytes[left]);
+    }
+}

--- a/Multiplayer/Networking/Auth/SteamSessionValidator.cs
+++ b/Multiplayer/Networking/Auth/SteamSessionValidator.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DV.Platform.Steam;
+using Multiplayer.Networking.TransportLayers;
+using Steamworks;
+using UnityEngine;
+
+namespace Multiplayer.Networking.Auth;
+
+/// <summary>
+///     Server-side verification of platform authentication tickets.
+/// </summary>
+/// <remarks>
+///     Verification is a round trip to Steam, so it cannot complete inside the connection-request handler.
+///     <see cref="BeginAuthSession" /> only reports that the ticket is well-formed; the authoritative
+///     answer arrives later on <see cref="SteamUser.OnValidateAuthTicketResponse" />. Callers must
+///     therefore accept the peer and withhold every privilege until <c>onSuccess</c> fires.
+///     <para>
+///         Every started session must be ended, on failure, timeout, or disconnect, or Steam keeps the
+///         session open and later tickets for that account are rejected as already in use.
+///     </para>
+/// </remarks>
+internal sealed class SteamSessionValidator : IDisposable
+{
+    /// <summary>How long an account may sit unverified before we give up on Steam answering.</summary>
+    private const float TIMEOUT_SECONDS = 15f;
+
+    private sealed class PendingSession
+    {
+        public ITransportPeer Peer;
+        public float ExpiresAt;
+        public Action OnSuccess;
+        public Action<string> OnFailure;
+    }
+
+    private readonly Dictionary<ulong, PendingSession> pending = new();
+
+    public int PendingCount => pending.Count;
+
+    public SteamSessionValidator()
+    {
+        SteamUser.OnValidateAuthTicketResponse += OnValidateAuthTicketResponse;
+    }
+
+    public void Dispose()
+    {
+        SteamUser.OnValidateAuthTicketResponse -= OnValidateAuthTicketResponse;
+
+        foreach (ulong steamId in pending.Keys.ToList())
+            End(steamId);
+
+        pending.Clear();
+    }
+
+    /// <summary>
+    ///     Starts verification of <paramref name="ticket" />. Returns false, with the reason logged, if
+    ///     Steam rejects the ticket outright; in that case neither callback will fire.
+    /// </summary>
+    public bool TryBegin(ITransportPeer peer, ulong steamId, byte[] ticket, Action onSuccess, Action<string> onFailure)
+    {
+        if (!DVSteamworks.Success || !SteamClient.IsValid)
+        {
+            Multiplayer.LogError("Cannot verify a player: Steam is unavailable on the host");
+            return false;
+        }
+
+        if (steamId == 0 || ticket == null || ticket.Length == 0)
+            return false;
+
+        if (pending.ContainsKey(steamId))
+        {
+            // A second connection attempt while the first is still being verified.
+            Multiplayer.LogWarning($"Already verifying SteamID {steamId}; rejecting the duplicate attempt");
+            return false;
+        }
+
+        BeginAuthResult result = SteamUser.BeginAuthSession(ticket, steamId);
+        if (result != BeginAuthResult.OK)
+        {
+            Multiplayer.LogWarning($"Steam rejected the ticket for SteamID {steamId}: {result}");
+            return false;
+        }
+
+        pending[steamId] = new PendingSession
+        {
+            Peer = peer,
+            ExpiresAt = Time.realtimeSinceStartup + TIMEOUT_SECONDS,
+            OnSuccess = onSuccess,
+            OnFailure = onFailure
+        };
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Ends the session of a peer that dropped before it was verified. Such a peer never became a
+    ///     player, so it can only be found by the peer itself.
+    /// </summary>
+    public void EndByPeer(ITransportPeer peer)
+    {
+        foreach (KeyValuePair<ulong, PendingSession> entry in pending.Where(e => e.Value.Peer == peer).ToList())
+            End(entry.Key);
+    }
+
+    /// <summary>Ends a verified session. Safe to call for an account we never started one for.</summary>
+    public void End(ulong steamId)
+    {
+        if (steamId == 0 || !DVSteamworks.Success || !SteamClient.IsValid)
+            return;
+
+        pending.Remove(steamId);
+        SteamUser.EndAuthSession(steamId);
+    }
+
+    /// <summary>Pumps Steam callbacks and expires sessions Steam never answered for.</summary>
+    public void Tick()
+    {
+        if (pending.Count == 0)
+            return;
+
+        try
+        {
+            SteamClient.RunCallbacks();
+        }
+        catch (Exception e)
+        {
+            Multiplayer.LogDebug(() => $"Steam callback pump threw: {e.Message}");
+        }
+
+        float now = Time.realtimeSinceStartup;
+
+        // Snapshot: Fail() mutates the dictionary.
+        foreach (KeyValuePair<ulong, PendingSession> entry in pending.Where(e => e.Value.ExpiresAt <= now).ToList())
+            Fail(entry.Key, "Steam did not answer in time");
+    }
+
+    private void OnValidateAuthTicketResponse(SteamId steamId, SteamId ownerSteamId, AuthResponse response)
+    {
+        if (!pending.TryGetValue(steamId.Value, out PendingSession session))
+            return;
+
+        if (response != AuthResponse.OK)
+        {
+            Fail(steamId.Value, response.ToString());
+            return;
+        }
+
+        // The account that owns the licence differs from the player under Steam Family Sharing. The
+        // player is still authenticated as themselves, which is all identity cares about.
+        if (ownerSteamId.Value != steamId.Value)
+            Multiplayer.Log($"SteamID {steamId.Value} is playing a copy owned by {ownerSteamId.Value}");
+
+        pending.Remove(steamId.Value);
+        session.OnSuccess();
+    }
+
+    private void Fail(ulong steamId, string reason)
+    {
+        if (!pending.TryGetValue(steamId, out PendingSession session))
+            return;
+
+        pending.Remove(steamId);
+        SteamUser.EndAuthSession(steamId);
+
+        Multiplayer.LogWarning($"Verification failed for SteamID {steamId}: {reason}");
+        session.OnFailure(reason);
+    }
+}

--- a/Multiplayer/Networking/Data/ServerPlayer.cs
+++ b/Multiplayer/Networking/Data/ServerPlayer.cs
@@ -39,6 +39,13 @@ public class ServerPlayer : IDisposable
     public string Username { get; set; }
     public string OriginalUsername { get; set; }
     public Guid Guid { get; set; }
+
+    /// <summary>
+    ///     The platform account this player proved ownership of at login, or 0 when the server does not
+    ///     require authentication. <see cref="Guid" /> is derived from it.
+    /// </summary>
+    public ulong SteamId { get; set; }
+
     public Vector3 RawPosition { get; set; }
     public float RawRotationY { get; set; }
     public ushort CarId { get; set; }

--- a/Multiplayer/Networking/Managers/Client/NetworkClient.cs
+++ b/Multiplayer/Networking/Managers/Client/NetworkClient.cs
@@ -24,6 +24,7 @@ using Multiplayer.Components.Networking.Train;
 using Multiplayer.Components.Networking.UI;
 using Multiplayer.Components.Networking.World;
 using Multiplayer.Components.SaveGame;
+using Multiplayer.Networking.Auth;
 using Multiplayer.Networking.Data;
 using Multiplayer.Networking.Data.Items;
 using Multiplayer.Networking.Data.Train;
@@ -110,10 +111,21 @@ public class NetworkClient : NetworkManager
         //netManager.Start();
         base.Start();
 
+        // The server verifies this ticket with Steam before granting us an identity. If we cannot mint
+        // one we still attempt the login: the server decides whether it will accept an unverified player.
+        if (!ClientAuthTicket.TryAcquire(out byte[] authTicket, out ulong steamId))
+        {
+            authTicket = [];
+            steamId = 0;
+            Log("No Steam authentication ticket available; the server may reject this login");
+        }
+
         ServerboundClientLoginPacket serverboundClientLoginPacket = new()
         {
             Username = this.Username,
             Guid = Multiplayer.Settings.GetGuid().ToByteArray(),
+            SteamId = steamId,
+            AuthTicket = authTicket,
             Password = password,
             BuildVersion = MainMenuControllerPatch.MenuProvider.BuildVersionString,
             Mods = ModCompatibilityManager.Instance.GetLocalMods()
@@ -132,6 +144,8 @@ public class NetworkClient : NetworkManager
     public override void Stop()
     {
         Log("Stopping client");
+        ClientAuthTicket.Release();
+
         if (!isAlsoHost && originalSession != null)
         {
             LogDebug(() => $"NetworkClient.Stop() destroying session... Original session is Null: {originalSession == null}");

--- a/Multiplayer/Networking/Managers/Server/NetworkServer.cs
+++ b/Multiplayer/Networking/Managers/Server/NetworkServer.cs
@@ -1,5 +1,6 @@
 using DV;
 using DV.Customization;
+using DV.Platform.Steam;
 using DV.Customization.Paint;
 using DV.Garages;
 using DV.InventorySystem;
@@ -20,6 +21,7 @@ using Multiplayer.Components.Networking;
 using Multiplayer.Components.Networking.Jobs;
 using Multiplayer.Components.Networking.Train;
 using Multiplayer.Components.Networking.World;
+using Multiplayer.Networking.Auth;
 using Multiplayer.Networking.Data;
 using Multiplayer.Networking.Data.Items;
 using Multiplayer.Networking.Data.Jobs;
@@ -40,6 +42,7 @@ using Multiplayer.Networking.Packets.Unconnected;
 using Multiplayer.Networking.TransportLayers;
 using Multiplayer.Patches.MainMenu;
 using Multiplayer.Utils;
+using Steamworks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -98,6 +101,9 @@ public class NetworkServer : NetworkManager
     // Permission checks registered by external mods, consulted before granting authoritative actions.
     private readonly List<PermissionCheckDelegate> permissionChecks = [];
 
+    // Verifies platform authentication tickets presented at login.
+    private readonly SteamSessionValidator authValidator = new();
+
     private uint lastTick;
 
     public NetworkServer(IDifficulty difficulty, Settings settings, bool singlePlayer, LobbyServerData serverData) : base(settings)
@@ -153,6 +159,8 @@ public class NetworkServer : NetworkManager
             player.Dispose();
 
         NetworkLifecycle.Instance.OnTick -= OnTick;
+
+        authValidator.Dispose();
 
         base.Stop();
     }
@@ -277,6 +285,10 @@ public class NetworkServer : NetworkManager
 
     private void OnTick(uint tick)
     {
+        // Before the IsLoaded gate: players are verified while the world is still streaming in, and a
+        // pending session that Steam never answers for must still time out.
+        authValidator.Tick();
+
         if (!IsLoaded)
             return;
 
@@ -359,9 +371,16 @@ public class NetworkServer : NetworkManager
     {
         LogDebug(() => $"OnPeerDisconnected({peer.Id})");
         if (!peerToPlayer.TryGetValue(peer, out ServerPlayer player))
+        {
+            // A peer that never finished logging in, e.g. one that dropped while being verified. It owns
+            // no player state, so there is nothing to tear down beyond its pending Steam session.
             LogWarning($"Peer {peer.GetType()}, peerId: {peer.Id} disconnected but no player found");
-        else
-            Log($"Player {player?.Username} disconnected: {disconnectReason}");
+            authValidator.EndByPeer(peer);
+            return;
+        }
+
+        Log($"Player {player.Username} disconnected: {disconnectReason}");
+        authValidator.End(player.SteamId);
 
         if (WorldStreamingInit.isLoaded)
             SaveGameManager.Instance.UpdateInternalData();
@@ -1140,7 +1159,9 @@ public class NetworkServer : NetworkManager
             return;
         }
 
-        if (PlayerCount >= Multiplayer.Settings.MaxPlayers || IsSinglePlayer && PlayerCount >= 1)
+        // Players still being verified hold a slot; they are not in PlayerCount yet.
+        int occupiedSlots = PlayerCount + authValidator.PendingCount;
+        if (occupiedSlots >= Multiplayer.Settings.MaxPlayers || IsSinglePlayer && occupiedSlots >= 1)
         {
             LogWarning("Denied login due to server being full!");
             ClientboundLoginResponsePacket denyPacket = new()
@@ -1188,22 +1209,91 @@ public class NetworkServer : NetworkManager
             return;
         }
 
+        if (IsSinglePlayer || !Multiplayer.Settings.RequireSteamAuth)
+        {
+            // Nothing to verify against, so the client's self-asserted guid is all we have.
+            CompleteLogin(request.Accept(), overrideUsername, packet.Username, guid, 0);
+            return;
+        }
+
+        if (!DVSteamworks.Success || !SteamClient.IsValid)
+        {
+            LogError("Steam is unavailable, so logins cannot be verified. Turn off \"Require Steam authentication\" to host without it.");
+            request.Reject(WritePacket(new ClientboundLoginResponsePacket { ReasonKey = Locale.DISCONN_REASON__AUTH_UNAVAILABLE_KEY }));
+            return;
+        }
+
+        if (packet.SteamId == 0 || packet.AuthTicket == null || packet.AuthTicket.Length == 0)
+        {
+            LogWarning($"Denied login for {packet.Username}: no authentication ticket was supplied");
+            request.Reject(WritePacket(new ClientboundLoginResponsePacket { ReasonKey = Locale.DISCONN_REASON__NOT_AUTHENTICATED_KEY }));
+            return;
+        }
+
+        // The identity is derived from the account, never from anything the client chose for itself.
+        Guid authenticatedGuid = PlayerIdentity.FromSteamId(packet.SteamId);
+
+        // Steam will not verify a ticket an account issued to itself, so the host cannot authenticate its
+        // own local client. Only a process on the host's machine can present the host's SteamID over
+        // loopback, and that machine is already fully trusted.
+        if (packet.SteamId == SteamClient.SteamId.Value && IPAddress.IsLoopback(request.RemoteEndPoint.Address))
+        {
+            CompleteLogin(request.Accept(), overrideUsername, packet.Username, authenticatedGuid, packet.SteamId);
+            return;
+        }
+
+        if (ServerPlayers.Any(existing => existing.SteamId == packet.SteamId))
+        {
+            LogWarning($"Denied login for {packet.Username}: SteamID {packet.SteamId} is already connected");
+            request.Reject(WritePacket(new ClientboundLoginResponsePacket { ReasonKey = Locale.DISCONN_REASON__ALREADY_CONNECTED_KEY }));
+            return;
+        }
+
+        // Verification is a round trip to Steam. Accept the peer but grant it nothing: no ServerPlayer
+        // exists until the ticket checks out, so every packet handler will refuse to serve it.
+        ITransportPeer pendingPeer = request.Accept();
+        string pendingUsername = packet.Username;
+        string pendingOverrideUsername = overrideUsername;
+        ulong pendingSteamId = packet.SteamId;
+
+        bool started = authValidator.TryBegin(
+            pendingPeer,
+            pendingSteamId,
+            packet.AuthTicket,
+            () => CompleteLogin(pendingPeer, pendingOverrideUsername, pendingUsername, authenticatedGuid, pendingSteamId),
+            reason => RejectUnauthenticated(pendingPeer, pendingUsername, reason));
+
+        if (!started)
+            RejectUnauthenticated(pendingPeer, pendingUsername, "Steam rejected the ticket");
+    }
+
+    private void RejectUnauthenticated(ITransportPeer peer, string username, string reason)
+    {
+        LogWarning($"Denied login for {username}: {reason}");
+        peer.Disconnect(WritePacket(new ClientboundLoginResponsePacket { ReasonKey = Locale.DISCONN_REASON__NOT_AUTHENTICATED_KEY }));
+    }
+
+    private void CompleteLogin(ITransportPeer peer, string overrideUsername, string originalUsername, Guid guid, ulong steamId)
+    {
         // Unpause physics
         if (AppUtil.Instance.IsTimePaused)
             AppUtil.Instance.RequestSystemOnValueChanged(0.0f);
-
-        ITransportPeer peer = request.Accept();
 
         ServerPlayer serverPlayer = new
         (
             peer,
             overrideUsername,
-            packet.Username,
+            originalUsername,
             guid
-        );
+        )
+        {
+            SteamId = steamId
+        };
 
         serverPlayers.Add(serverPlayer.PlayerId, serverPlayer);
         peerToPlayer.Add(peer, serverPlayer);
+
+        Log($"{serverPlayer.Username} logged in as {guid}{(steamId != 0 ? $" (SteamID {steamId})" : " (unauthenticated)")}");
 
         ClientboundLoginResponsePacket acceptPacket = new()
         {

--- a/Multiplayer/Networking/Managers/Server/NetworkServer.cs
+++ b/Multiplayer/Networking/Managers/Server/NetworkServer.cs
@@ -12,6 +12,7 @@ using DV.WeatherSystem;
 using Humanizer;
 using LiteNetLib;
 using LiteNetLib.Utils;
+using MPAPI.Interfaces;
 using MPAPI.Interfaces.Packets;
 using MPAPI.Types;
 using Multiplayer.API;
@@ -93,6 +94,9 @@ public class NetworkServer : NetworkManager
 
     private readonly ChatManager _chatManager = new();
     public ChatManager ChatManager => _chatManager;
+
+    // Permission checks registered by external mods, consulted before granting authoritative actions.
+    private readonly List<PermissionCheckDelegate> permissionChecks = [];
 
     private uint lastTick;
 
@@ -302,6 +306,47 @@ public class NetworkServer : NetworkManager
         }
         return wrapper;
     }
+
+    #region Permissions
+    public void RegisterPermissionCheck(PermissionCheckDelegate check)
+    {
+        if (check != null && !permissionChecks.Contains(check))
+            permissionChecks.Add(check);
+    }
+
+    public void UnregisterPermissionCheck(PermissionCheckDelegate check)
+    {
+        permissionChecks.Remove(check);
+    }
+
+    /// <summary>
+    /// Consults every registered permission check for the given action. Returns <c>true</c> if the action
+    /// is permitted (no checks registered, or all checks allow it); <c>false</c> if any check vetoes it.
+    /// A throwing check is treated as a veto (fail-closed) and logged.
+    /// </summary>
+    public bool CheckPermission(ServerPlayer player, PermissionAction action, TrainCar target)
+    {
+        if (permissionChecks.Count == 0)
+            return true;
+
+        var wrapper = GetWrapper(player);
+        foreach (var check in permissionChecks)
+        {
+            try
+            {
+                if (!check(wrapper, action, target))
+                    return false;
+            }
+            catch (Exception e)
+            {
+                LogError($"Permission check threw for player \"{player?.Username}\" action {action}; denying. {e}");
+                return false;
+            }
+        }
+
+        return true;
+    }
+    #endregion
 
     #region Net Events
 

--- a/Multiplayer/Networking/Packets/Serverbound/ServerboundClientLoginPacket.cs
+++ b/Multiplayer/Networking/Packets/Serverbound/ServerboundClientLoginPacket.cs
@@ -5,7 +5,19 @@ namespace Multiplayer.Networking.Packets.Serverbound;
 public class ServerboundClientLoginPacket
 {
     public string Username { get; set; }
+
+    /// <summary>
+    ///     Legacy self-asserted identity. Only honoured when the server does not require authentication,
+    ///     since a client can put any value here. Authenticated servers derive the identity from
+    ///     <see cref="SteamId" /> once the ticket below has been verified.
+    /// </summary>
     public byte[] Guid { get; set; }
+
+    public ulong SteamId { get; set; }
+
+    /// <summary>Steam-minted proof that the sender owns <see cref="SteamId" />. Empty if unavailable.</summary>
+    public byte[] AuthTicket { get; set; } = [];
+
     public string Password { get; set; }
     public string BuildVersion { get; set; }
     public ModInfo[] Mods { get; set; }

--- a/Multiplayer/Settings.cs
+++ b/Multiplayer/Settings.cs
@@ -48,6 +48,8 @@ public class Settings : UnityModManager.ModSettings, IDrawable
     public int MaxPlayers = 4;
     [Draw("Port", Tooltip = "The port that your server will listen on. You generally don't need to change this.")]
     public int Port = 7777;
+    [Draw("Require Steam authentication", Tooltip = "Verify each player's Steam account as they join, so nobody can join as somebody else. Turn this off only for trusted or non-Steam players: when it is off, players choose their own identity and can impersonate each other.")]
+    public bool RequireSteamAuth = true;
     [Draw("Details", Tooltip = "Details shown in the server browser.")]
     public string Details = "";
 

--- a/MultiplayerAPI/Interfaces/IPlayer.cs
+++ b/MultiplayerAPI/Interfaces/IPlayer.cs
@@ -18,6 +18,19 @@ namespace MPAPI.Interfaces
         public byte PlayerId { get; }
 
         /// <summary>
+        /// Gets the stable, persistent unique identifier for this player.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="PlayerId"/> (which is reassigned as players join and leave), this value is
+        /// stable for a given player across reconnects and sessions, making it a suitable key for
+        /// persisting or looking up per-player state.
+        /// Only the server tracks player identities, so this is populated on <see cref="IServer"/>-side
+        /// player objects. On a pure client, remote players are not identity-tracked and this returns
+        /// <see cref="System.Guid.Empty"/>.
+        /// </remarks>
+        Guid UniqueId { get; }
+
+        /// <summary>
         /// Gets the username of the player.
         /// </summary>
         public string Username { get; }

--- a/MultiplayerAPI/Interfaces/IPlayer.cs
+++ b/MultiplayerAPI/Interfaces/IPlayer.cs
@@ -24,11 +24,36 @@ namespace MPAPI.Interfaces
         /// Unlike <see cref="PlayerId"/> (which is reassigned as players join and leave), this value is
         /// stable for a given player across reconnects and sessions, making it a suitable key for
         /// persisting or looking up per-player state.
+        /// <para>
+        /// On a server that requires authentication (the default), this is derived from the player's
+        /// platform account, after the server has verified with that platform that the player owns it.
+        /// A player cannot present an identity that is not theirs, so this value is safe to key
+        /// security-sensitive state on.
+        /// </para>
+        /// <para>
+        /// A host may switch authentication off, for LAN or non-Steam play. On such a server this value
+        /// is whatever the client asserted about itself and proves nothing: any client can claim any
+        /// identity. Consumers that key sensitive state on it should decide whether to trust an
+        /// unauthenticated server rather than assume this value is meaningful.
+        /// </para>
         /// Only the server tracks player identities, so this is populated on <see cref="IServer"/>-side
         /// player objects. On a pure client, remote players are not identity-tracked and this returns
         /// <see cref="System.Guid.Empty"/>.
         /// </remarks>
         Guid UniqueId { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this player proved ownership of their <see cref="UniqueId"/>.
+        /// </summary>
+        /// <remarks>
+        /// <c>true</c> when the server verified the player's platform account with that platform at
+        /// login. <c>false</c> when the host has authentication switched off, in which case
+        /// <see cref="UniqueId"/> is self-asserted and interchangeable between clients.
+        /// Consumers that persist per-player state, grant privileges, or otherwise treat identity as a
+        /// security boundary should refuse to act when this is <c>false</c>.
+        /// Always <c>false</c> on <see cref="IClient"/>-side player objects, which do not track identity.
+        /// </remarks>
+        bool IsAuthenticated { get; }
 
         /// <summary>
         /// Gets the username of the player.

--- a/MultiplayerAPI/Interfaces/IServer.cs
+++ b/MultiplayerAPI/Interfaces/IServer.cs
@@ -22,6 +22,15 @@ public delegate void ChatCommandCallback(string message, IPlayer sender);
 public delegate bool ChatFilterDelegate(ref string message, IPlayer sender);
 
 /// <summary>
+/// Represents a method that decides whether a player is permitted to perform a server-authoritative action.
+/// </summary>
+/// <param name="player">The player attempting the action.</param>
+/// <param name="action">The action being attempted.</param>
+/// <param name="target">The train car the action targets, or <c>null</c> if not applicable.</param>
+/// <returns><c>true</c> to allow the action; <c>false</c> to veto it.</returns>
+public delegate bool PermissionCheckDelegate(IPlayer player, PermissionAction action, TrainCar target);
+
+/// <summary>
 /// Interface for interacting with Multiplayer mod server instances.
 /// </summary>
 public interface IServer
@@ -198,5 +207,26 @@ public interface IServer
     /// This method is experimental and may be replaced in future.
     /// </remarks>
     void SetPlayerCrewName(IPlayer player, string crewName);
+    #endregion
+
+    #region Permissions
+    /// <summary>
+    /// Registers a permission check that the server consults <b>before</b> granting a player a
+    /// server-authoritative action (see <see cref="PermissionAction"/>).
+    /// </summary>
+    /// <param name="check">The check to register.</param>
+    /// <remarks>
+    /// All registered checks are consulted; the action is only permitted if <b>every</b> check returns
+    /// <c>true</c>. A single check returning <c>false</c> vetoes the action, and the base mod denies the
+    /// request exactly as it would for a failed built-in validation. Checks run on the server tick thread
+    /// and should be fast and side-effect free. If no checks are registered, base-mod behaviour is unchanged.
+    /// </remarks>
+    void RegisterPermissionCheck(PermissionCheckDelegate check);
+
+    /// <summary>
+    /// Unregisters a previously registered permission check.
+    /// </summary>
+    /// <param name="check">The check to remove.</param>
+    void UnregisterPermissionCheck(PermissionCheckDelegate check);
     #endregion
 }

--- a/MultiplayerAPI/MultiplayerAPI.csproj
+++ b/MultiplayerAPI/MultiplayerAPI.csproj
@@ -4,8 +4,8 @@
         <TargetFramework>net48</TargetFramework>
         <LangVersion>latest</LangVersion>
         <RootNamespace>MPAPI</RootNamespace>
-        <InformationalVersion>1.1.0.0</InformationalVersion>
-        <Version>1.1.0.0</Version>
+        <InformationalVersion>1.2.0.0</InformationalVersion>
+        <Version>1.2.0.0</Version>
 
         <!-- NuGet Package Configuration -->
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/MultiplayerAPI/MultiplayerAPI.csproj
+++ b/MultiplayerAPI/MultiplayerAPI.csproj
@@ -4,8 +4,8 @@
         <TargetFramework>net48</TargetFramework>
         <LangVersion>latest</LangVersion>
         <RootNamespace>MPAPI</RootNamespace>
-        <InformationalVersion>1.2.0.0</InformationalVersion>
-        <Version>1.2.0.0</Version>
+        <InformationalVersion>1.3.0.0</InformationalVersion>
+        <Version>1.3.0.0</Version>
 
         <!-- NuGet Package Configuration -->
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/MultiplayerAPI/Types/PermissionAction.cs
+++ b/MultiplayerAPI/Types/PermissionAction.cs
@@ -1,0 +1,24 @@
+namespace MPAPI.Types;
+
+/// <summary>
+/// Identifies a server-authoritative action a player is attempting, so registered mods can
+/// veto it before the base mod grants it. See <see cref="MPAPI.Interfaces.IServer.RegisterPermissionCheck"/>.
+/// </summary>
+public enum PermissionAction
+{
+    /// <summary>
+    /// The player is requesting control authority over a cab control (throttle, brake, reverser, etc.)
+    /// on the target car.
+    /// </summary>
+    TrainControlAuthority,
+
+    /// <summary>
+    /// The player is requesting to rerail the target car.
+    /// </summary>
+    Rerail,
+
+    /// <summary>
+    /// The player is requesting to restore (summon/repair) the target locomotive.
+    /// </summary>
+    Restore,
+}


### PR DESCRIPTION
## Summary

One step closer to being a dedicated server!

Adds a proven, stable player identity and a per-player permission-check hook, and authenticates that identity against Steam at login.

- **Stable `IPlayer.UniqueId` (`Guid`)** surfaces the server-side `ServerPlayer.Guid` so API consumers have a key that survives reconnects/sessions instead of the reassignable `PlayerId`. Server-only; the client wrapper returns `Guid.Empty`.
- **Per-player permission-check hook** — `IServer.RegisterPermissionCheck` / `UnregisterPermissionCheck`. All registered checks must return `true` or the server-authoritative action (`PermissionAction`) is denied (any veto = deny; a throwing check fails closed). Wired at the control-authority grant; `Rerail`/`Restore` reserved for the same pattern.
- **Steam-backed authentication.** The client mints a Steam auth ticket and sends it with its SteamID in the login packet; the server validates via `SteamUser.BeginAuthSession` and derives `ServerPlayer.Guid` from a deterministic name-based UUID of the SteamID (`PlayerIdentity.FromSteamId`). The client's self-asserted guid is ignored. Verification is asynchronous, so the peer is accepted but no `ServerPlayer` is created until Steam answers — an unverified peer can do nothing. `IPlayer.IsAuthenticated` reports whether ownership was proven.
- **`Settings.RequireSteamAuth`** (default on) turns this off for LAN / non-Steam / Oculus / Steam-offline play, falling back to the self-asserted guid (`IsAuthenticated` false).
- Bumps the MultiplayerAPI version to **1.3.0.0** for the new API surface.

## Log line

On a successful authenticated login the host's `player.log` shows:

```
[Multiplayer] [Server] `PLAYER` logged in as `UUIDPART-`… (SteamID `STEAMID`)
```

(unauthenticated logins log `(unauthenticated)` instead of the SteamID.)

🤖 Generated with [Claude Code](https://claude.com/claude-code) - Created by me, the human!
