### PR TITLE
Feature/networked hazmat

### DIFF
--- a/Multiplayer/Components/Networking/World/NetworkedHazmatManager.cs
+++ b/Multiplayer/Components/Networking/World/NetworkedHazmatManager.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using DV.ThingTypes;
+using DV.Utils;
+using Multiplayer.Networking.Data;
+using Multiplayer.Networking.Packets.Clientbound.World;
+using UnityEngine;
+
+namespace Multiplayer.Components.Networking.World;
+
+/// <summary>
+/// Replicates DV's hazmat terrain grid (spilled liquids, terrain fires, corrosion, biohazard,
+/// radiation) from the host to every client.
+///
+/// Why replicate instead of letting each client simulate:
+/// HazmatTileManager is a cellular automaton stepped one phase per frame, and both ignition (random
+/// chance + random delay) and reaction decay (frame delta time) are non-deterministic. Two machines
+/// starting from identical state diverge within seconds, so fires would spread differently or not at
+/// all. Instead the host is authoritative and clients only render: HazmatSimulationPatch neuters the
+/// client's simulation phases and its grid-mutating entry points, and this manager streams the host's
+/// tile state to them.
+///
+/// What makes this cheap: a tile's key (HazmatGridTile.gridPosition) is a packed grid coordinate derived
+/// from an origin-shift-corrected world position, so it names the same patch of terrain on every machine
+/// despite each client shifting its origin independently. Tiles can therefore be addressed by id, and the
+/// payload is DV's own per-tile serializer (HazmatGridTile.SerializeData) — the same bytes the game
+/// writes into a save.
+///
+/// Liquid spills are not forwarded from clients: the leaking car exists on the host too (cargo health is
+/// synced), so the host's own particles produce the spill. Only ignition is forwarded, because a client
+/// can ignite terrain with something the host cannot infer (a lighter).
+/// </summary>
+public class NetworkedHazmatManager : SingletonBehaviour<NetworkedHazmatManager>
+{
+    // Fires and spills evolve slowly by network standards; 4 Hz is plenty and keeps the diff scan off the
+    // hot tick.
+    private const int SYNC_INTERVAL_TICKS = NetworkLifecycle.TICK_RATE / 4;
+
+    // Tiles per packet. A large spill can touch hundreds of tiles; chunking keeps a single packet at a
+    // sane size and spreads the join backfill over several sends.
+    private const int MAX_TILES_PER_PACKET = 128;
+
+    // How often a client retries tiles it couldn't place because their terrain wasn't streamed in yet.
+    private const float DEFERRED_RETRY_INTERVAL = 2f;
+
+    /*
+     * Server state
+     */
+
+    // Last state we told clients about, per tile. Also serves as the "tiles clients know about" set:
+    // dropping out of it is what produces a removal.
+    private readonly Dictionary<int, int> sentSignatures = new Dictionary<int, int>();
+
+    private readonly List<HazmatGridTile> dirtyTiles = new List<HazmatGridTile>();
+    private readonly List<int> removedTiles = new List<int>();
+
+    /*
+     * Client state
+     */
+
+    // Tiles whose terrain chunk isn't loaded yet (a fire on the far side of the map). Their blob is held
+    // here — the host has already marked them sent and won't repeat itself — and retried until the
+    // terrain streams in. Latest blob per tile wins.
+    private readonly Dictionary<int, byte[]> deferredTiles = new Dictionary<int, byte[]>();
+    private float nextDeferredRetry;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        NetworkLifecycle.Instance.OnTick += Common_OnTick;
+    }
+
+    protected override void OnDestroy()
+    {
+        base.OnDestroy();
+        if (UnloadWatcher.isQuitting)
+            return;
+
+        if (NetworkLifecycle.Instance != null)
+            NetworkLifecycle.Instance.OnTick -= Common_OnTick;
+    }
+
+    private static HazmatTileManager TileManager => SingletonBehaviour<HazmatTileManager>.Instance;
+
+    private void Common_OnTick(uint tick)
+    {
+        if (NetworkLifecycle.Instance.IsSinglePlayer)
+            return;
+
+        if (NetworkLifecycle.Instance.IsHost())
+        {
+            if (tick % SYNC_INTERVAL_TICKS == 0)
+                Server_SendDirtyTiles();
+
+            return;
+        }
+
+        if (deferredTiles.Count > 0 && Time.time >= nextDeferredRetry)
+        {
+            nextDeferredRetry = Time.time + DEFERRED_RETRY_INTERVAL;
+            Client_RetryDeferredTiles();
+        }
+    }
+
+    /*
+     * Server
+     */
+
+    private void Server_SendDirtyTiles()
+    {
+        HazmatTileManager manager = TileManager;
+        if (manager == null || manager.TileDictionary == null)
+            return;
+
+        dirtyTiles.Clear();
+        removedTiles.Clear();
+
+        foreach (KeyValuePair<int, HazmatGridTile> entry in manager.TileDictionary)
+        {
+            int signature = Signature(entry.Value);
+            if (sentSignatures.TryGetValue(entry.Key, out int sent) && sent == signature)
+                continue;
+
+            sentSignatures[entry.Key] = signature;
+            dirtyTiles.Add(entry.Value);
+        }
+
+        // Anything we've sent before that the host's CleanUp has since dropped.
+        foreach (int coords in sentSignatures.Keys)
+            if (!manager.TileDictionary.ContainsKey(coords))
+                removedTiles.Add(coords);
+
+        foreach (int coords in removedTiles)
+            sentSignatures.Remove(coords);
+
+        if (dirtyTiles.Count == 0 && removedTiles.Count == 0)
+            return;
+
+        // Removals ride with the first chunk; a removed tile is by definition not in the dirty set, so
+        // there's no ordering hazard between the two.
+        if (dirtyTiles.Count == 0)
+        {
+            NetworkLifecycle.Instance.Server.SendHazmatTiles(null, removedTiles.ToArray(), null);
+            return;
+        }
+
+        for (int i = 0; i < dirtyTiles.Count; i += MAX_TILES_PER_PACKET)
+        {
+            int count = Mathf.Min(MAX_TILES_PER_PACKET, dirtyTiles.Count - i);
+            NetworkLifecycle.Instance.Server.SendHazmatTiles(
+                Serialize(dirtyTiles, i, count),
+                i == 0 ? removedTiles.ToArray() : null,
+                null);
+        }
+    }
+
+    /// <summary>
+    /// Send the whole grid to a joining player. Called on PlayerLoadingState.ReadyForTiles.
+    /// </summary>
+    public void Server_SendFullSnapshot(ServerPlayer player)
+    {
+        HazmatTileManager manager = TileManager;
+        if (manager == null || manager.TileDictionary == null || manager.TileDictionary.Count == 0)
+            return;
+
+        var all = new List<HazmatGridTile>(manager.TileDictionary.Values);
+        NetworkLifecycle.Instance.Server.LogDebug(() => $"Sending hazmat backfill of {all.Count} tiles to {player.Username}");
+
+        for (int i = 0; i < all.Count; i += MAX_TILES_PER_PACKET)
+        {
+            int count = Mathf.Min(MAX_TILES_PER_PACKET, all.Count - i);
+            NetworkLifecycle.Instance.Server.SendHazmatTiles(Serialize(all, i, count), null, player);
+        }
+    }
+
+    /// <summary>
+    /// Apply a client's ignition request to the host's real grid. The resulting tile state reaches
+    /// everyone (including the requester) through the normal dirty-tile stream.
+    /// </summary>
+    public void Server_ReceiveIgnite(int gridPosition, float ignitionStrength)
+    {
+        HazmatTileManager manager = TileManager;
+        if (manager == null)
+            return;
+
+        manager.IgniteTile(gridPosition, ignitionStrength);
+    }
+
+    /// <summary>
+    /// Quantised fingerprint of everything we replicate, so float jitter in an effectively unchanged tile
+    /// doesn't re-send it on every scan.
+    /// </summary>
+    private static int Signature(HazmatGridTile tile)
+    {
+        unchecked
+        {
+            int hash = 17;
+            hash = hash * 31 + Mathf.RoundToInt(tile.currentWeight * 100f);
+            hash = hash * 31 + Mathf.RoundToInt(tile.burnTime * 10f);
+            hash = hash * 31 + Flags(tile);
+
+            foreach (KeyValuePair<CargoType, float> liquid in tile.liquidContent)
+                hash ^= ((int)liquid.Key * 397) ^ Mathf.RoundToInt(liquid.Value * 100f);
+
+            return hash;
+        }
+    }
+
+    private static int Flags(HazmatGridTile tile)
+    {
+        int flags = 0;
+        if (tile.IsIgnited) flags |= 1;
+        if (tile.IsCorroded) flags |= 2;
+        if (tile.IsDefiled) flags |= 4;
+        if (tile.IsRadiated) flags |= 8;
+        return flags;
+    }
+
+    /*
+     * Wire format
+     *
+     * int count, then per tile: int gridPosition, ushort blobLength, blob.
+     *
+     * The blob is HazmatGridTile.SerializeData's output. It's length-prefixed rather than written back to
+     * back like DV does in a save file, because a client may fail to place an individual tile (its
+     * terrain isn't loaded) and must be able to skip or stash it without losing its place in the stream.
+     */
+
+    private static byte[] Serialize(List<HazmatGridTile> tiles, int offset, int count)
+    {
+        using (var stream = new MemoryStream())
+        using (var writer = new BinaryWriter(stream))
+        using (var tileStream = new MemoryStream())
+        using (var tileWriter = new BinaryWriter(tileStream))
+        {
+            writer.Write(count);
+
+            for (int i = offset; i < offset + count; i++)
+            {
+                HazmatGridTile tile = tiles[i];
+
+                tileStream.SetLength(0);
+                tile.SerializeData(tileWriter);
+                tileWriter.Flush();
+
+                writer.Write(tile.gridPosition);
+                writer.Write((ushort)tileStream.Length);
+                writer.Write(tileStream.GetBuffer(), 0, (int)tileStream.Length);
+            }
+
+            writer.Flush();
+            return stream.ToArray();
+        }
+    }
+
+    /*
+     * Client
+     */
+
+    public void Client_ReceiveTiles(ClientboundHazmatTilesPacket packet)
+    {
+        HazmatTileManager manager = TileManager;
+        if (manager == null)
+            return;
+
+        if (packet.TileData != null && packet.TileData.Length > 0)
+            Client_ApplyTiles(manager, packet.TileData);
+
+        if (packet.RemovedTiles == null)
+            return;
+
+        foreach (int coords in packet.RemovedTiles)
+        {
+            deferredTiles.Remove(coords);
+            Client_RemoveTile(manager, coords);
+        }
+    }
+
+    private void Client_ApplyTiles(HazmatTileManager manager, byte[] data)
+    {
+        using (var stream = new MemoryStream(data))
+        using (var reader = new BinaryReader(stream))
+        {
+            int count = reader.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                int coords = reader.ReadInt32();
+                byte[] blob = reader.ReadBytes(reader.ReadUInt16());
+
+                if (!Client_ApplyTile(manager, coords, blob))
+                    deferredTiles[coords] = blob;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Place one tile. Returns false if it couldn't be placed *yet* — the terrain it sits on isn't
+    /// streamed in, so the caller should hold onto it and retry.
+    /// </summary>
+    private static bool Client_ApplyTile(HazmatTileManager manager, int coords, byte[] blob)
+    {
+        HazmatGridTile tile;
+        try
+        {
+            // autoCreate: the tile won't exist locally — the client never runs the simulation that would
+            // have created it. This reads the terrain heightmap, so it throws (or produces nothing) when
+            // the terrain chunk isn't loaded.
+            tile = manager.GetTileFromCoords(coords, true);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        if (tile == null)
+            return false;
+
+        // DeserializeData does liquidContent.Add(), which throws on a key that's already there. DV only
+        // ever deserialises into a freshly created tile; we deserialise into the same tile repeatedly.
+        tile.liquidContent.Clear();
+
+        using (var stream = new MemoryStream(blob))
+        using (var reader = new BinaryReader(stream))
+            tile.DeserializeData(reader, HazmatTileManager.HAZMAT_DATA_VERSION);
+
+        Client_ReconcileEffects(manager, tile);
+        return true;
+    }
+
+    private void Client_RetryDeferredTiles()
+    {
+        HazmatTileManager manager = TileManager;
+        if (manager == null)
+            return;
+
+        var placed = new List<int>();
+        foreach (KeyValuePair<int, byte[]> deferred in deferredTiles)
+            if (Client_ApplyTile(manager, deferred.Key, deferred.Value))
+                placed.Add(deferred.Key);
+
+        foreach (int coords in placed)
+            deferredTiles.Remove(coords);
+    }
+
+    /// <summary>
+    /// Bring a tile's visuals in line with the state just deserialised into it. This mirrors what
+    /// HazmatTileManager.DeserializeFromStream does when loading a save, plus the teardown half that the
+    /// load path never needs: a tile can stop burning, and the client's own CleanUp is disabled.
+    /// </summary>
+    private static void Client_ReconcileEffects(HazmatTileManager manager, HazmatGridTile tile)
+    {
+        if (tile.IsIgnited)
+        {
+            // Idempotent — restarts the existing effect rather than spawning a second one.
+            manager.BurnTerrainTile(tile);
+        }
+        else if (tile.terrainFireEffects != null)
+        {
+            tile.terrainFireEffects.RemoveEffects();
+            tile.terrainFireEffects = null;
+            manager.IgnitedTileCoords.Remove(tile.gridPosition);
+        }
+
+        if (tile.IsCorroded)
+        {
+            manager.CorrodeTerrainTile(tile);
+        }
+        else if (tile.terrainCorrosiveEffects != null)
+        {
+            tile.terrainCorrosiveEffects.RemoveEffects();
+            tile.terrainCorrosiveEffects = null;
+        }
+
+        if (tile.IsDefiled)
+        {
+            manager.DefileTile(tile);
+        }
+        else if (tile.terrainBiohazardEffects != null)
+        {
+            tile.terrainBiohazardEffects.RemoveEffects();
+            tile.terrainBiohazardEffects = null;
+        }
+
+        // Queue the terrain splat (the wet/scorched texture blend). PrepareAllTerrainSplats and
+        // ApplyTerrainSplats still run on the client — only the state-evolving phases are disabled.
+        manager.PrepareTerrainPaintData(HazmatTileManager.LIQUID_TEXTURE_INDEX, tile.currentWeight, tile.gridPosition);
+    }
+
+    private static void Client_RemoveTile(HazmatTileManager manager, int coords)
+    {
+        if (!manager.TileDictionary.TryGetValue(coords, out HazmatGridTile tile))
+            return;
+
+        if (tile.terrainFireEffects != null)
+            tile.terrainFireEffects.RemoveEffects();
+        if (tile.terrainCorrosiveEffects != null)
+            tile.terrainCorrosiveEffects.RemoveEffects();
+        if (tile.terrainBiohazardEffects != null)
+            tile.terrainBiohazardEffects.RemoveEffects();
+
+        manager.IgnitedTileCoords.Remove(coords);
+        manager.TileDictionary.Remove(coords);
+        manager.tileList.RemoveAll(kvp => kvp.Key == coords);
+
+        // Wash the liquid texture back off the terrain.
+        manager.PrepareTerrainPaintData(HazmatTileManager.LIQUID_TEXTURE_INDEX, 0f, coords);
+    }
+}

--- a/Multiplayer/Components/Networking/World/NetworkedHazmatManager.cs
+++ b/Multiplayer/Components/Networking/World/NetworkedHazmatManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using DV.ThingTypes;
 using DV.Utils;
+using JetBrains.Annotations;
 using Multiplayer.Networking.Data;
 using Multiplayer.Networking.Packets.Clientbound.World;
 using UnityEngine;
@@ -405,5 +406,11 @@ public class NetworkedHazmatManager : SingletonBehaviour<NetworkedHazmatManager>
 
         // Wash the liquid texture back off the terrain.
         manager.PrepareTerrainPaintData(HazmatTileManager.LIQUID_TEXTURE_INDEX, 0f, coords);
+    }
+
+    [UsedImplicitly]
+    public new static string AllowAutoCreate()
+    {
+        return $"[{nameof(NetworkedHazmatManager)}]";
     }
 }

--- a/Multiplayer/Networking/Managers/Client/NetworkClient.cs
+++ b/Multiplayer/Networking/Managers/Client/NetworkClient.cs
@@ -38,6 +38,7 @@ using Multiplayer.Networking.Packets.Common.Train;
 using Multiplayer.Networking.Packets.Serverbound;
 using Multiplayer.Networking.Packets.Serverbound.Jobs;
 using Multiplayer.Networking.Packets.Serverbound.Train;
+using Multiplayer.Networking.Packets.Serverbound.World;
 using Multiplayer.Networking.TransportLayers;
 using Multiplayer.Patches.MainMenu;
 using Multiplayer.Patches.SaveGame;
@@ -163,6 +164,7 @@ public class NetworkClient : NetworkManager
         netPacketProcessor.SubscribeReusable<ClientboundTimeAdvancePacket>(OnClientboundTimeAdvancePacket);
         netPacketProcessor.SubscribeReusable<CommonChangeJunctionPacket>(OnCommonChangeJunctionPacket);
         netPacketProcessor.SubscribeReusable<CommonRotateTurntablePacket>(OnCommonRotateTurntablePacket);
+        netPacketProcessor.SubscribeReusable<ClientboundHazmatTilesPacket>(OnClientboundHazmatTilesPacket);
 
 
         // Player Management
@@ -282,6 +284,8 @@ public class NetworkClient : NetworkManager
 
         Log($"Starting Item Manager...");
         NetworkedItemManager.Instance.CheckInstance();
+        Log($"Starting Hazmat Manager...");
+        NetworkedHazmatManager.Instance.CheckInstance();
         Log($"Caching World Items...");
         NetworkedItemManager.Instance.CacheWorldItems();
         Log($"Initialising Cash Registers...");
@@ -691,6 +695,16 @@ public class NetworkClient : NetworkManager
         if (!NetworkedJunction.Get(packet.NetId, out NetworkedJunction junction))
             return;
         junction.Switch(packet.Mode, packet.SelectedBranch);
+    }
+
+    private void OnClientboundHazmatTilesPacket(ClientboundHazmatTilesPacket packet)
+    {
+        // The server excludes the host's loopback client from this packet, but guard anyway: the host's
+        // grid is the authority, and deserialising into it would clobber the live simulation.
+        if (NetworkLifecycle.Instance.IsHost())
+            return;
+
+        NetworkedHazmatManager.Instance.Client_ReceiveTiles(packet);
     }
 
     private void OnCommonRotateTurntablePacket(CommonRotateTurntablePacket packet)
@@ -1475,6 +1489,20 @@ public class NetworkClient : NetworkManager
             NetId = netId,
             SelectedBranch = selectedBranch,
             Mode = (byte)mode
+        }, DeliveryMethod.ReliableOrdered);
+    }
+
+    /// <summary>
+    /// Ask the host to ignite a terrain tile. Clients don't simulate the hazmat grid, so their local
+    /// ignition attempts (a lighter dropped into a spill) are blocked and forwarded here instead — see
+    /// HazmatSimulationPatch.
+    /// </summary>
+    public void SendHazmatIgnite(int gridPosition, float ignitionStrength)
+    {
+        SendPacketToServer(new ServerboundHazmatIgnitePacket
+        {
+            GridPosition = gridPosition,
+            IgnitionStrength = ignitionStrength
         }, DeliveryMethod.ReliableOrdered);
     }
 

--- a/Multiplayer/Networking/Managers/Server/NetworkServer.cs
+++ b/Multiplayer/Networking/Managers/Server/NetworkServer.cs
@@ -35,6 +35,7 @@ using Multiplayer.Networking.Packets.Common.Train;
 using Multiplayer.Networking.Packets.Serverbound;
 using Multiplayer.Networking.Packets.Serverbound.Jobs;
 using Multiplayer.Networking.Packets.Serverbound.Train;
+using Multiplayer.Networking.Packets.Serverbound.World;
 using Multiplayer.Networking.Packets.Unconnected;
 using Multiplayer.Networking.TransportLayers;
 using Multiplayer.Patches.MainMenu;
@@ -167,6 +168,7 @@ public class NetworkServer : NetworkManager
 
         netPacketProcessor.SubscribeReusable<CommonChangeJunctionPacket, ITransportPeer>(OnCommonChangeJunctionPacket);
         netPacketProcessor.SubscribeReusable<CommonRotateTurntablePacket, ITransportPeer>(OnCommonRotateTurntablePacket);
+        netPacketProcessor.SubscribeReusable<ServerboundHazmatIgnitePacket, ITransportPeer>(OnServerboundHazmatIgnitePacket);
 
         netPacketProcessor.SubscribeReusable<CommonPitStopInteractionPacket, ITransportPeer>(OnCommonPitStopInteractionPacket);
         netPacketProcessor.SubscribeNetSerializable<CommonPitStopPlugInteractionPacket, ITransportPeer>(OnCommonPitStopPlugInteractionPacket);
@@ -643,6 +645,29 @@ public class NetworkServer : NetworkManager
             SendPacket(sendToPlayer.Peer, packet, DeliveryMethod.ReliableUnordered);
         else
             SendPacketToAll(packet, DeliveryMethod.ReliableUnordered, PlayerLoadingState.ReadyForTrainSets, true);
+    }
+
+    /// <summary>
+    /// Send hazmat terrain state. <paramref name="sendToPlayer"/> targets a single player (the join
+    /// backfill); null broadcasts the periodic delta to everyone past ReadyForTiles.
+    /// </summary>
+    public void SendHazmatTiles(byte[] tileData, int[] removedTiles, ServerPlayer sendToPlayer)
+    {
+        var packet = new ClientboundHazmatTilesPacket
+        {
+            TileData = tileData ?? Array.Empty<byte>(),
+            RemovedTiles = removedTiles ?? Array.Empty<int>()
+        };
+
+        if (sendToPlayer != null)
+        {
+            SendPacket(sendToPlayer.Peer, packet, DeliveryMethod.ReliableOrdered);
+            return;
+        }
+
+        // excludeSelf: the host's loopback client must not receive this. It shares the grid with the
+        // server that just produced it, and applying it would clobber the live simulation.
+        SendPacketToAll(packet, DeliveryMethod.ReliableOrdered, PlayerLoadingState.ReadyForTiles, null, true);
     }
 
     public void SendRestorationStateChange(ushort netId, LocoRestorationController.RestorationState newState, ushort[] transportCars)
@@ -1308,7 +1333,10 @@ public class NetworkServer : NetworkManager
                 break;
 
             case PlayerLoadingState.ReadyForTiles:
-                // Send Hazmat data
+                // Send Hazmat data: the whole terrain grid (spills, fires, corrosion). Clients don't
+                // simulate it, so without this backfill a joiner sees clean ground where the host has a
+                // fire burning.
+                NetworkedHazmatManager.Instance.Server_SendFullSnapshot(player);
                 break;
 
             case PlayerLoadingState.Complete:
@@ -1403,6 +1431,19 @@ public class NetworkServer : NetworkManager
             PlayerLoadingState.ReadyForWorldState,
             peer
         );
+    }
+
+    private void OnServerboundHazmatIgnitePacket(ServerboundHazmatIgnitePacket packet, ITransportPeer peer)
+    {
+        if (!peerToPlayer.TryGetValue(peer, out _))
+        {
+            LogWarning($"Received hazmat ignite from peerId {peer.Id}, but could not find matching player.");
+            return;
+        }
+
+        // Ignite the host's real tile. The result reaches every client (including the requester) through
+        // NetworkedHazmatManager's normal dirty-tile stream, so there's nothing to rebroadcast here.
+        NetworkedHazmatManager.Instance.Server_ReceiveIgnite(packet.GridPosition, packet.IgnitionStrength);
     }
 
     private void OnCommonChangeJunctionPacket(CommonChangeJunctionPacket packet, ITransportPeer peer)

--- a/Multiplayer/Networking/Packets/Clientbound/World/ClientboundHazmatTilesPacket.cs
+++ b/Multiplayer/Networking/Packets/Clientbound/World/ClientboundHazmatTilesPacket.cs
@@ -1,0 +1,16 @@
+namespace Multiplayer.Networking.Packets.Clientbound.World;
+
+// Host -> client snapshot of the hazmat terrain grid (spilled liquids, fires, corrosion, biohazard,
+// radiation). See NetworkedHazmatManager for the format and why the grid is replicated rather than
+// simulated on each client.
+public class ClientboundHazmatTilesPacket
+{
+    // Tiles whose state changed, in NetworkedHazmatManager's wire format:
+    //   int count, then per tile: int gridPosition + HazmatGridTile.SerializeData() blob.
+    // Used for both the join backfill (every tile) and the periodic deltas.
+    public byte[] TileData { get; set; }
+
+    // Packed grid coords of tiles the host's simulation dropped entirely (fire burnt out and the
+    // liquid is gone). The client removes their effects and forgets them.
+    public int[] RemovedTiles { get; set; }
+}

--- a/Multiplayer/Networking/Packets/Serverbound/World/ServerboundHazmatIgnitePacket.cs
+++ b/Multiplayer/Networking/Packets/Serverbound/World/ServerboundHazmatIgnitePacket.cs
@@ -1,0 +1,13 @@
+namespace Multiplayer.Networking.Packets.Serverbound.World;
+
+// Client -> host request to ignite a terrain tile (a lighter thrown into a spill, sparks, an explosion).
+// Clients don't run the hazmat simulation, so every local ignition attempt is blocked and forwarded here
+// instead; the host ignites its real tile and the result comes back as a ClientboundHazmatTilesPacket.
+//
+// GridPosition is HazmatTileManager's packed grid coordinate. It's derived from an origin-shift-corrected
+// world position, so it means the same tile on every machine.
+public class ServerboundHazmatIgnitePacket
+{
+    public int GridPosition { get; set; }
+    public float IgnitionStrength { get; set; }
+}

--- a/Multiplayer/Patches/World/Hazmat/HazmatSimulationPatch.cs
+++ b/Multiplayer/Patches/World/Hazmat/HazmatSimulationPatch.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using DV.ThingTypes;
+using HarmonyLib;
+using Multiplayer.Components.Networking;
+using UnityEngine;
+
+namespace Multiplayer.Patches.World.Hazmat;
+
+/// <summary>
+/// Makes the hazmat terrain grid host-authoritative.
+///
+/// DV's HazmatTileManager is a cellular automaton with random ignition chances and frame-delta-driven
+/// decay, so it cannot be run independently on each machine and stay in agreement — two clients would
+/// grow different fires from the same spill. The host therefore keeps simulating, and on clients this
+/// patch disables both the simulation phases and every entry point that mutates the grid.
+/// NetworkedHazmatManager streams the host's tile state in instead.
+///
+/// Deliberately left running on the client: PrepareAllTerrainSplats and ApplyTerrainSplats. Those only
+/// paint the terrain from tile state, and NetworkedHazmatManager depends on them to render what it
+/// receives.
+///
+/// Ignition is the one thing forwarded upstream — a client can set terrain alight with a lighter, which
+/// the host has no other way of knowing about.
+/// </summary>
+[HarmonyPatch(typeof(HazmatTileManager))]
+public static class HazmatSimulationPatch
+{
+    // A client's own sparks/explosions try to ignite tiles the host is igniting anyway. Ignition is
+    // idempotent, but forwarding every attempt during e.g. sustained wheelslip would be a packet storm,
+    // so the same tile is only requested once per cooldown.
+    private const float IGNITE_REQUEST_COOLDOWN = 1f;
+    private static readonly Dictionary<int, float> lastIgniteRequest = new Dictionary<int, float>();
+
+    /// <summary>
+    /// True when we're a client that must not touch the grid. False for the host (which includes single
+    /// player, where the host is the only player) so vanilla behaviour is completely untouched there.
+    /// </summary>
+    private static bool IsRemoteClient =>
+        NetworkLifecycle.Instance != null &&
+        NetworkLifecycle.Instance.IsClientRunning &&
+        !NetworkLifecycle.Instance.IsHost();
+
+    /*
+     * Simulation phases — the cellular automaton itself.
+     */
+
+    [HarmonyPatch(nameof(HazmatTileManager.EvolveLiquidCellularAutomaton))]
+    [HarmonyPrefix]
+    private static bool EvolveLiquidCellularAutomaton() => !IsRemoteClient;
+
+    [HarmonyPatch(nameof(HazmatTileManager.PrepareReaction))]
+    [HarmonyPrefix]
+    private static bool PrepareReaction() => !IsRemoteClient;
+
+    [HarmonyPatch(nameof(HazmatTileManager.ProcessReaction))]
+    [HarmonyPrefix]
+    private static bool ProcessReaction() => !IsRemoteClient;
+
+    // The host tells us which tiles to drop (ClientboundHazmatTilesPacket.RemovedTiles); removing them
+    // locally on our own schedule would delete tiles the host still considers alive.
+    [HarmonyPatch(nameof(HazmatTileManager.CleanUp))]
+    [HarmonyPrefix]
+    private static bool CleanUp() => !IsRemoteClient;
+
+    /*
+     * Grid mutation entry points.
+     */
+
+    // Drains the queue that OnParticleCollision fills. Blocked together with the queue itself below, so
+    // nothing accumulates.
+    [HarmonyPatch(nameof(HazmatTileManager.UpdateTileLiquidContentExternal))]
+    [HarmonyPrefix]
+    private static bool UpdateTileLiquidContentExternal() => !IsRemoteClient;
+
+    // Leaking cargo spraying particles onto the terrain. Not forwarded to the host: the leaking car
+    // exists there too (cargo health is synced), so the host's own particles produce the same spill and
+    // send it back to us as tile state.
+    [HarmonyPatch(nameof(HazmatTileManager.UpdateTileLiquidToBeAddedDictionary))]
+    [HarmonyPrefix]
+    private static bool UpdateTileLiquidToBeAddedDictionary() => !IsRemoteClient;
+
+    // Both IgniteTile overloads and every Igniter path funnel through here, so it's the one place to
+    // intercept ignition.
+    [HarmonyPatch(nameof(HazmatTileManager.IgniteTerrainTile))]
+    [HarmonyPrefix]
+    private static bool IgniteTerrainTile(HazmatGridTile tile, float ignitionStrength, ref bool __result)
+    {
+        if (!IsRemoteClient)
+            return true;
+
+        __result = false;
+
+        if (tile == null)
+            return false;
+
+        if (lastIgniteRequest.TryGetValue(tile.gridPosition, out float last) && Time.time - last < IGNITE_REQUEST_COOLDOWN)
+            return false;
+
+        lastIgniteRequest[tile.gridPosition] = Time.time;
+        NetworkLifecycle.Instance.Client.SendHazmatIgnite(tile.gridPosition, ignitionStrength);
+        return false;
+    }
+}
+
+/// <summary>
+/// The remaining grid mutations, which CargoReaction*.PostExplosionBehavior and CargoReactionRadioactive
+/// apply straight to a tile without going through HazmatTileManager. Same reasoning as above: on a client
+/// the host's tile state is the truth, so local writes are dropped.
+/// </summary>
+[HarmonyPatch(typeof(HazmatGridTile))]
+public static class HazmatGridTilePatch
+{
+    private static bool IsRemoteClient =>
+        NetworkLifecycle.Instance != null &&
+        NetworkLifecycle.Instance.IsClientRunning &&
+        !NetworkLifecycle.Instance.IsHost();
+
+    [HarmonyPatch(nameof(HazmatGridTile.AddLiquidAmount))]
+    [HarmonyPrefix]
+    private static bool AddLiquidAmount(CargoType cargoType, float amountToAdd) => !IsRemoteClient;
+
+    [HarmonyPatch(nameof(HazmatGridTile.AddRadiation))]
+    [HarmonyPrefix]
+    private static bool AddRadiation(float amountToAdd) => !IsRemoteClient;
+}


### PR DESCRIPTION
## Problem

DV's hazmat system — spilled cargo liquid, terrain fires, corrosion, biohazard, radiation — was **entirely un-networked**. Every machine ran its own independent copy of `HazmatTileManager`, so a client saw clean ground where the host had a fire burning. The only trace of it in the mod was a placeholder: a `PlayerLoadingState.ReadyForTiles` case with the comment `// Send Hazmat data` and an empty body.

## Why it can't just be simulated per-client

`HazmatTileManager.Update()` is a cellular automaton advancing one phase per frame (`EvolveLiquidCellularAutomaton` → `PrepareAllTerrainSplats` → `ApplyTerrainSplats` → `PrepareReaction` → `ProcessReaction` → `CleanUp`). Both ignition (random chance + random delay in `HazmatGridTile.ProcessIgnition`) and reaction decay (driven by frame delta time) are non-deterministic, so two machines starting from identical state diverge within seconds — fires would spread differently, or not at all.

So this is **host-authoritative replication, not shared simulation**.

## Approach

- **`NetworkedHazmatManager`** — the host diffs its `TileDictionary` at 4 Hz and streams changed tiles plus dropped-tile coords as `ClientboundHazmatTilesPacket`. Joining players get the full grid at `ReadyForTiles` (the loading state that already existed as an empty placeholder for exactly this).
- **`HazmatSimulationPatch`** — on clients only, no-ops the four simulation phases and every grid-mutating entry point (`UpdateTileLiquidContentExternal`, `UpdateTileLiquidToBeAddedDictionary`, `IgniteTerrainTile`, `HazmatGridTile.AddLiquidAmount`/`AddRadiation`). The terrain-splat painting is deliberately left running — it only paints from tile state, and the apply path relies on it.

## What makes this cheap

A tile's key (`HazmatGridTile.gridPosition`) is a packed grid coordinate derived from an **origin-shift-corrected** world position, so it names the same patch of terrain on every machine despite each client shifting its origin independently. Tiles are addressable by a plain `int` — no position payload. The wire payload is DV's own per-tile serializer (`HazmatGridTile.SerializeData`), the same bytes the game writes into a save, which also means **persistence across a host restart is free** (the host's real grid is saved by DV as usual).

## Direction of traffic

Liquid spills are **not** forwarded from clients: the leaking car exists on the host too (cargo health is already synced), so the host's own particles produce the same spill. Only **ignition** is forwarded (`ServerboundHazmatIgnitePacket`), because a client can set terrain alight with something the host can't infer — a lighter. The client's blocked `IgniteTerrainTile` (the single choke point that both `IgniteTile` overloads and every `Igniter` path funnel through) forwards the request instead, rate-limited per tile.

The host's loopback client is excluded from the tile packet (`excludeSelf` + an `IsHost()` guard in the handler): it shares the grid with the server that just produced it, so applying would clobber the live sim. This is the opposite of the junction/customization idiom, where the host deliberately applies *via* loopback.

## Two traps worth knowing about

1. `HazmatGridTile.DeserializeData` does `liquidContent.Add()`, which **throws on a key already present**. DV only ever deserialises into a freshly created tile; we re-apply to the same tile repeatedly, so the apply path clears `liquidContent` first.
2. A client can receive a tile whose terrain chunk isn't streamed in (a fire across the map). `GetTileFromCoords(autoCreate: true)` reads the heightmap and fails there, so those tiles are parked in `deferredTiles` and retried every 2s — the host has already marked them sent and won't repeat itself, so dropping them would lose them permanently.

## Testing

Initial two-instance (`LocalTest`) run went well — host→client propagation confirmed.

## Known gap

No distance culling: every ready client receives every dirty tile. Bounded by actual spill size and chunked at 128 tiles/packet, so fine for normal play, but a pathological map-wide fire would be chatty.

🧔‍♂️ Created by me - 🤖 Generated with [Claude Code](https://claude.com/claude-code) 