### PR TITLE
Rework Work Train In Use Checks

### DIFF
--- a/Multiplayer/API/ClientPlayerWrapper.cs
+++ b/Multiplayer/API/ClientPlayerWrapper.cs
@@ -34,5 +34,5 @@ public class ClientPlayerWrapper : IPlayer
     public bool IsHost => _isHost;
     public int Ping => _networkedPlayer.GetPing();
     public bool IsOnCar => _networkedPlayer.IsOnCar;
-    public TrainCar OccupiedCar => _networkedPlayer.OccupiedCar;
+    public TrainCar OccupiedCar => _networkedPlayer?.OccupiedCar?.TrainCar;
 }

--- a/Multiplayer/Components/Networking/Player/NetworkedPlayer.cs
+++ b/Multiplayer/Components/Networking/Player/NetworkedPlayer.cs
@@ -70,7 +70,7 @@ public class NetworkedPlayer : MonoBehaviour
     }
 
     internal bool IsOnCar { get; private set; }
-    internal TrainCar OccupiedCar { get; private set; }
+    internal NetworkedTrainCar OccupiedCar { get; private set; }
 
     private Transform selfTransform;
     private PlayerPostureFlags currentPosture;
@@ -427,13 +427,29 @@ public class NetworkedPlayer : MonoBehaviour
 
     public void UpdateCar(ushort netId)
     {
-        IsOnCar = NetworkedTrainCar.TryGet(netId, out TrainCar trainCar);
-        OccupiedCar = trainCar;
+       bool willBeOnCar = NetworkedTrainCar.TryGet(netId, out NetworkedTrainCar newTrainCar);
+
+        if (OccupiedCar != null)
+        {
+            if (OccupiedCar == newTrainCar)
+                return;
+
+            OccupiedCar.Client_RemovePlayer(this);
+        }
+
+        IsOnCar = willBeOnCar && newTrainCar != null;
 
         if (IsOnCar)
+        {
+            OccupiedCar = newTrainCar;
             selfTransform.SetParent(OccupiedCar.transform, true);
+            OccupiedCar.Client_PlayerOnCar(this);
+        }
         else
+        {
+            OccupiedCar = null;
             selfTransform.SetParent(null, true);
+        }
     }
 
     /// <summary>

--- a/Multiplayer/Components/Networking/Train/NetworkedTrainCar.cs
+++ b/Multiplayer/Components/Networking/Train/NetworkedTrainCar.cs
@@ -160,7 +160,6 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
     public uint TicksSinceSync = uint.MaxValue;
 
     public uint lastTickProcessed = 0;
-    public bool HasPlayers => PlayerManager.Car == TrainCar || GetComponentInChildren<NetworkedPlayer>() != null;
 
     private Bogie bogie1;
     private Bogie bogie2;
@@ -208,6 +207,10 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
     private ServerPlayer frontInteractionPlayer;
     private ServerPlayer rearInteractionPlayer;
 
+    // Player tracking
+    private readonly HashSet<ServerPlayer> serverPlayersInCar = [];
+
+    // Control authority tracking
     private readonly Dictionary<uint, ServerPlayer> portAuthority = [];
 
     #endregion
@@ -220,7 +223,10 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
     public TickedQueue<BogieData> client_bogie1Queue;
     public TickedQueue<BogieData> client_bogie2Queue;
 
+    // Player tracking
+    private readonly HashSet<NetworkedPlayer> networkedPlayersInCar = [];
 
+    //Coupler interaction
     private Coupler couplerInteraction;
     private ChainCouplerInteraction.State originalState;
     private Coupler originalCoupledTo;
@@ -459,6 +465,10 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
 
             StartCoroutine(Server_WaitForLogicCar());
         }
+        else
+        {
+            NetworkLifecycle.Instance.Client.ClientPlayerManager.OnPlayerDisconnected += Client_PlayerDisconnected;
+        }
 
         NetworkLifecycle.Instance?.Client.SendTrainSyncRequest(NetId);
     }
@@ -683,6 +693,10 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
                 TrainCar.logicCar.CargoLoaded -= Server_OnCargoLoaded;
                 TrainCar.logicCar.CargoUnloaded -= Server_OnCargoUnloaded;
             }
+        }
+        else
+        {
+            NetworkLifecycle.Instance.Client.ClientPlayerManager.OnPlayerDisconnected -= Client_PlayerDisconnected;
         }
 
         CurrentID = string.Empty;
@@ -962,7 +976,7 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
                 $"rearInteracting: {rearInteracting}, rearInteractionPeer: {rearInteractionPlayer}"
                 );
 
-        //Ensure no one else is interacting
+        // Ensure no one else is interacting
         if (packet.IsFrontCoupler && frontInteracting && player != frontInteractionPlayer ||
            packet.IsFrontCoupler == false && rearInteracting && player != rearInteractionPlayer)
         {
@@ -1103,6 +1117,28 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
             portAuthority.Remove(kvp.Key);
             NetworkLifecycle.Instance.Server.SendTrainControlAuthorityUpdate(NetId, kvp.Key, ControlAuthorityState.Released);
         }
+
+        Server_RemovePlayer(player);
+    }
+
+    public void Server_PlayerOnCar(ServerPlayer player)
+    {
+        Multiplayer.LogDebug(() => $"Server_PlayerOnCar() {player?.Username} is on car {CurrentID}, netId: {NetId}, player.CarId: {player?.CarId}");
+        if (player == null || player.CarId == NetId)
+            return;
+
+        if (player.CarId != 0 && TryGet(player.CarId, out NetworkedTrainCar otherCar) && otherCar != null)
+            otherCar.Server_RemovePlayer(player);
+
+        serverPlayersInCar.Add(player);
+        TrainCar?.visitChecker?.OnPlayerCarChanged(TrainCar);
+    }
+
+    public void Server_RemovePlayer(ServerPlayer player)
+    {
+        Multiplayer.LogDebug(() => $"Server_RemovePlayer() {player?.Username} is leaving car {CurrentID}, netId: {NetId}, player.CarId: {player?.CarId}");
+        serverPlayersInCar.Remove(player);
+        TrainCar?.visitChecker?.OnPlayerCarChanged(TrainCar);
     }
     #endregion
 
@@ -1735,6 +1771,15 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
         targetPaint.UpdateTheme();
         TrainCar.OnPaintThemeChanged(targetPaint);
     }
+
+    public bool HasPlayers()
+    {
+        if (NetworkLifecycle.Instance.IsHost())
+            return PlayerManager.Car == TrainCar || serverPlayersInCar.Count > 0;
+
+        return PlayerManager.Car == TrainCar || networkedPlayersInCar.Count > 0;
+    }
+
     #endregion
 
     #region Client
@@ -2086,6 +2131,32 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
 
         if (handCarBarController != null)
             handCarBarController.enabled = shouldEnable;
+    }
+
+    public void Client_PlayerDisconnected(NetworkedPlayer player)
+    {
+        Multiplayer.LogDebug(() => $"Client_PlayerDisconnected({player?.Username}) car [{CurrentID}, {NetId}]");
+        networkedPlayersInCar.Remove(player);
+        TrainCar?.visitChecker?.OnPlayerCarChanged(TrainCar);
+    }
+
+    public void Client_PlayerOnCar(NetworkedPlayer player)
+    {
+        Multiplayer.LogDebug(() => $"Client_PlayerOnCar({player?.Username}) car [{CurrentID}, {NetId}], OccupiedCar: {player?.OccupiedCar?.CurrentID}");
+        if (player == null || player.OccupiedCar == TrainCar)
+            return;
+
+        player?.OccupiedCar?.Client_RemovePlayer(player);
+
+        networkedPlayersInCar.Add(player);
+        TrainCar?.visitChecker?.OnPlayerCarChanged(TrainCar);
+    }
+
+    public void Client_RemovePlayer(NetworkedPlayer player)
+    {
+        Multiplayer.LogDebug(() => $"Client_RemovePlayer({player?.Username}) car [{CurrentID}, {NetId}]");
+        networkedPlayersInCar.Remove(player);
+        TrainCar?.visitChecker?.OnPlayerCarChanged(TrainCar);
     }
     #endregion
 }

--- a/Multiplayer/Components/Networking/Train/NetworkedTrainCar.cs
+++ b/Multiplayer/Components/Networking/Train/NetworkedTrainCar.cs
@@ -8,6 +8,7 @@ using DV.MultipleUnit;
 using DV.Simulation.Brake;
 using DV.Simulation.Cars;
 using DV.Simulation.Controllers;
+using DV.Simulation.Fuses;
 using DV.ThingTypes;
 using JetBrains.Annotations;
 using LocoSim.Definitions;
@@ -24,6 +25,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using static DV.HUD.InteriorControlsManager;
 
 namespace Multiplayer.Components.Networking.Train;
 
@@ -106,6 +108,7 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
     private const float MAX_PAINT_DISTANCE_SQ = (CommsRadioPaintjob.SIGNAL_RANGE + DISTANCE_TOLERANCE) * (CommsRadioPaintjob.SIGNAL_RANGE + DISTANCE_TOLERANCE);
     private const float POSITION_UPDATE_THRESHOLD = 0.1f; // TrainCar must have a bigger delta to apply position update
     private const float INTERIOR_CONTROLS_TIMEOUT = 2f;
+    private const float IN_USE_THRESHOLD = 10 * 60f; // 10 minutes for in use to expire
 
     #region Port and Fuse Map
 
@@ -1780,6 +1783,99 @@ public class NetworkedTrainCar : IdMonoBehaviour<ushort, NetworkedTrainCar>
         return PlayerManager.Car == TrainCar || networkedPlayersInCar.Count > 0;
     }
 
+    /// <summary>
+    /// Checks whether a train car is in use for the purposes of calling Work Trains.
+    /// TrainCar is considered in use if:
+    ///  - There are any players on the TrainCar or its connected carriages/locomotives.
+    ///  - The TrainCar is moving.
+    ///  - The TrainCar is connected to a train with one or more active jobs.
+    ///  - The TrainCar is connected to another locomotive with a running engine.
+    ///  - The TrainCar's engine (or equivalent) is running.
+    ///  - The TrainCar's handbrake is not applied.
+    ///  - The TrainCar's engine is off and brake applied, but has been occupied in the last 10 mins
+    /// </summary>
+    /// <returns></returns>
+    public bool InUse()
+    {
+        if (HasPlayers() || !TrainCar.isStationary)
+            return true;
+
+        if (TrainCar.IsLoco)
+            return LocoInUse();
+        else
+            return CarInUse();
+    }
+
+    private bool LocoInUse()
+    {
+        bool handbrakeApplied = brakeSystem?.handbrakePosition > 0f;
+        bool engineRunning = EngineRunning();
+
+        if (engineRunning || !handbrakeApplied)
+            return true;
+
+        // Check if the TrainCar has been occupied in the last n minutes
+        if ((TrainCar.visitChecker?.IsRecentlyVisited ?? false) &&
+            TrainCar.visitChecker?.recentlyVisitedTimer?.ElapsedTime < IN_USE_THRESHOLD)
+            return true;
+
+        if (TrainCar.trainset == null || TrainCar.trainset.cars == null || TrainCar.trainset.cars.Count == 0)
+            return false;
+
+        foreach (var otherTrainCar in TrainCar.trainset.cars)
+        {
+            if (otherTrainCar == null || otherTrainCar == TrainCar)
+                continue;
+
+            if (TryGetFromTrainCar(otherTrainCar, out var otherNetTrainCar) && otherNetTrainCar != null)
+                if (otherNetTrainCar.InUse())
+                    return true;
+        }
+
+        return false;
+    }
+
+    private bool CarInUse()
+    {
+        if (!TrainCar.IsLoco && TrainCar.logicCar != null)
+        {
+            var job = JobsManager.Instance.GetJobOfCar(TrainCar.logicCar, true);
+            if (job != null)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether the train car's engine (or equivalent) is running.
+    /// TrainCars without an engine (e.g. electric locos) are considered to have a running engine if the main/electrics fuse is on.
+    /// </summary>
+    /// <returns>true if the engine is running, false otherwise</returns>
+    public bool EngineRunning()
+    {
+        if (!TrainCar.IsLoco)
+            return false;
+
+        // Steam and diesel locos have an engineOn reader port, electric locos do not
+        var engineReaderPort = simController?.controlsOverrider?.EngineOnReader?.engineOnPort;
+        if (engineReaderPort != null)
+        {
+            return engineReaderPort.Value > 0f;
+        }
+        else
+        {
+            // Attempt to get the state of the main/electrics fuse
+            if (interiorControlsManager?.TryGetControl(ControlType.ElectricsFuse, out var controlReference) ?? false)
+            {
+                var fuseFeeder = controlReference.controlImplBase.GetComponent<InteractableFuseFeeder>();
+                string fuseId = fuseFeeder?.fuseId;
+                simulationFlow.TryGetFuse(fuseId, out Fuse fuse);
+                return fuse?.State ?? false;
+            }
+        }
+        return false;
+    }
     #endregion
 
     #region Client

--- a/Multiplayer/Networking/Managers/Server/NetworkServer.cs
+++ b/Multiplayer/Networking/Managers/Server/NetworkServer.cs
@@ -1406,6 +1406,17 @@ public class NetworkServer : NetworkManager
             return;
         }
 
+        // If the player's car has changed, remove the player from the old car
+        if (packet.CarID == 0 && player.CarId != 0)
+        {
+            if (NetworkedTrainCar.TryGet(player.CarId, out NetworkedTrainCar currentCar) && currentCar != null)
+                currentCar.Server_RemovePlayer(player);
+        }
+
+        // If the player is on a car, update the car's player list
+        if (packet.CarID != 0 && NetworkedTrainCar.TryGet(packet.CarID, out NetworkedTrainCar newCar) && newCar != null)
+            newCar.Server_PlayerOnCar(player);
+
         // Merge incoming delta into stored state
         player.TrackingData = player.TrackingData.MergeFrom(packet.TrackingData);
         player.CarId = packet.CarID;
@@ -1689,7 +1700,7 @@ public class NetworkServer : NetworkManager
         if (!NetworkedTrainCar.TryGet(packet.NetId, out NetworkedTrainCar networkedTrainCar))
             return;
 
-        if (networkedTrainCar.HasPlayers)
+        if (networkedTrainCar.HasPlayers())
         {
             LogWarning($"{player.Username} tried to delete a train with players in it!");
             return;

--- a/Multiplayer/Networking/Managers/Server/NetworkServer.cs
+++ b/Multiplayer/Networking/Managers/Server/NetworkServer.cs
@@ -1728,6 +1728,8 @@ public class NetworkServer : NetworkManager
         var garageRef = trainCar.GetComponent<HomeGarageReference>();
         if (garageRef != null && garageRef.garageCarSpawner != null)
         {
+            // Clear the countdown so players can request the car immediately
+            trainCar.visitChecker?.recentlyVisitedTimer?.StopCountdown();
             garageRef.garageCarSpawner.ReturnCarHome(trainCar);
         }
         else
@@ -1815,6 +1817,7 @@ public class NetworkServer : NetworkManager
     private void OnServerboundWorkTrainRequestPacket(ServerboundWorkTrainRequestPacket packet, ITransportPeer peer)
     {
         TrainCar trainCar;
+        NetworkedTrainCar networkedTrainCar;
 
         var rpcResponse = new SpawnResponse() { Response = SpawnResponse.ResponseType.InUse };
 
@@ -1834,25 +1837,6 @@ public class NetworkServer : NetworkManager
             LogWarning($"{player.Username} tried to request a work train with invalid livery Id: {packet.LiveryId}");
             return;
         }
-
-        // Check if this is a garage loco
-        bool isGarageCar = GarageCarSpawner.Spawners.TryGetValue(livery, out var selectedGarageSpawner);
-
-        // Check funds
-        if (isGarageCar)
-        {
-            var price = Mathf.Min(selectedGarageSpawner.garageType.summonPrice, Globals.G.GameParams.WorkTrainSummonMaxPrice);
-            if (!Inventory.Instance.RemoveMoney(price))
-            {
-                LogWarning($"{player.Username} tried to request a work train without enough money to do so!");
-                rpcResponse.Response = SpawnResponse.ResponseType.InsufficientFunds;
-                SendRpcResponse(packet.TicketId, rpcResponse, peer);
-
-                return;
-            }
-        }
-
-        trainCar = isGarageCar ? selectedGarageSpawner.GetCar(livery) : CarSpawner.Instance.AllCars.FirstOrDefault(tc => tc.carLivery == livery);
 
         // Check spawn location on track is valid
         var kinked = networkedRailTrack.RailTrack.GetKinkedPointSet().points;
@@ -1884,6 +1868,42 @@ public class NetworkServer : NetworkManager
 
         Vector3 forward = packet.WithTrackDirection ? spawnPoint.forward : -spawnPoint.forward;
 
+        // Check if this is a garage loco
+        bool isGarageCar = GarageCarSpawner.Spawners.TryGetValue(livery, out var selectedGarageSpawner);
+
+        trainCar = isGarageCar ? selectedGarageSpawner.GetCar(livery) : CarSpawner.Instance.AllCars.FirstOrDefault(tc => tc.carLivery == livery);
+
+        if (isGarageCar)
+        {
+            // Check if the car exists and is not in use
+            if (trainCar != null)
+            {
+                if (NetworkedTrainCar.TryGetFromTrainCar(trainCar, out networkedTrainCar) && networkedTrainCar != null)
+                {
+                    if (networkedTrainCar.InUse())
+                    {
+                        SendRpcResponse(packet.TicketId, rpcResponse, peer);
+                        return;
+                    }
+                }
+                else
+                {
+                    LogWarning($"{player.Username} tried to request a work train of {livery.id} but NetworkedTrainCar not found");
+                    return;
+                }
+            }
+
+            var price = Mathf.Min(selectedGarageSpawner.garageType.summonPrice, Globals.G.GameParams.WorkTrainSummonMaxPrice);
+            if (!Inventory.Instance.RemoveMoney(price))
+            {
+                LogWarning($"{player.Username} tried to request a work train without enough money to do so!");
+                rpcResponse.Response = SpawnResponse.ResponseType.InsufficientFunds;
+                SendRpcResponse(packet.TicketId, rpcResponse, peer);
+
+                return;
+            }
+        }
+
         if (trainCar == null)
         {
             LogDebug(() => $"OnServerboundWorkTrainRequestPacket() {player.Username} tried to request a work train of {livery.id} but no existing car found, spawning new car");
@@ -1893,58 +1913,6 @@ public class NetworkServer : NetworkManager
         }
         else
         {
-            // Check if is currently in use/recently used
-            if (trainCar.IsTeleporting || !trainCar.isStationary)
-            {
-                LogDebug(() => $"OnServerboundWorkTrainRequestPacket() {player.Username} tried to request a work train of {livery.id} but the car is in use teleporting: {trainCar.IsTeleporting}, stationary: {trainCar.isStationary}");
-
-                SendRpcResponse(packet.TicketId, rpcResponse, peer);
-                return;
-            }
-
-            bool recentlyVisited = false;
-            bool attachedToJob = false;
-            int ctr = 0;
-            var cars = trainCar.trainset.cars;
-            while (!recentlyVisited && ctr < cars.Count)
-            {
-                var car = cars[ctr];
-
-                if (car.IsLoco)
-                {
-                    var visitChecker = car.visitChecker;
-                    recentlyVisited = (visitChecker != null && visitChecker.IsRecentlyVisited);
-                }
-                else
-                {
-                    var job = JobsManager.Instance.GetJobOfCar(car.logicCar);
-                    attachedToJob = (job != null && job.State == JobState.InProgress);
-                }
-                ctr++;
-            }
-
-            if (recentlyVisited || attachedToJob)
-            {
-                LogDebug(() => $"OnServerboundWorkTrainRequestPacket() {player.Username} tried to request a work train of {livery.id} but the car is in use ({(recentlyVisited ? "recently visited" : "")}{(recentlyVisited && attachedToJob ? ", " : "")}{(attachedToJob ? "attached to an active job" : "")})");
-                SendRpcResponse(packet.TicketId, rpcResponse, peer);
-                return;
-            }
-
-            // Confirm no players are currently in the car
-            if (!NetworkedTrainCar.TryGetFromTrainCar(trainCar, out var networkedTrainCar))
-            {
-                LogError($"OnServerboundWorkTrainRequestPacket() {player.Username} tried to request a work train of {livery.id} but NetworkedTrainCar was not found for {trainCar?.ID}");
-                SendRpcResponse(packet.TicketId, rpcResponse, peer);
-                return;
-            }
-
-            if (networkedTrainCar.HasPlayers)
-            {
-                LogDebug(() => $"OnServerboundWorkTrainRequestPacket() {player.Username} tried to request a work train of {livery.id} but the car is occupied");
-                SendRpcResponse(packet.TicketId, rpcResponse, peer);
-                return;
-            }
-
             // Checks passed, call the work train
             trainCar = CarSpawner.Instance.SpawnCrewVehicle(livery, networkedRailTrack.RailTrack, (Vector3)spawnPoint.position, forward, selectedGarageSpawner);
         }

--- a/Multiplayer/Patches/CommsRadio/CommsRadioCarDeleterPatch.cs
+++ b/Multiplayer/Patches/CommsRadio/CommsRadioCarDeleterPatch.cs
@@ -25,9 +25,9 @@ public static class CommsRadioCarDeleterPatch
 
         __instance.carToDelete.TryNetworked(out NetworkedTrainCar networkedTrainCar);
 
-        if (networkedTrainCar == null || networkedTrainCar != null && (networkedTrainCar.HasPlayers || networkedTrainCar.NetId == 0))
+        if (networkedTrainCar == null || networkedTrainCar != null && (networkedTrainCar.HasPlayers() || networkedTrainCar.NetId == 0))
         {
-            Multiplayer.LogDebug(() => $"CommsRadioCarDeleter unable to delete car: {__instance.carToDelete.name}, hasPlayer: {networkedTrainCar?.HasPlayers}, netId {networkedTrainCar?.NetId} ");
+            Multiplayer.LogDebug(() => $"CommsRadioCarDeleter unable to delete car: {__instance.carToDelete.name}, hasPlayer: {networkedTrainCar?.HasPlayers()}, netId {networkedTrainCar?.NetId} ");
             CommsRadioController.PlayAudioFromRadio(__instance.cancelSound, __instance.transform);
             __instance.ClearFlags();
             return false;
@@ -62,7 +62,7 @@ public static class CommsRadioCarDeleterPatch
         if (!Physics.Raycast(__instance.signalOrigin.position, __instance.signalOrigin.forward, out __instance.hit, CommsRadioCarDeleter.SIGNAL_RANGE, __instance.trainCarMask))
             return true;
         TrainCar car = TrainCar.Resolve(__instance.hit.transform.root);
-        if (car != null && car.TryNetworked(out NetworkedTrainCar networkedTrainCar) && !networkedTrainCar.HasPlayers)
+        if (car != null && car.TryNetworked(out NetworkedTrainCar networkedTrainCar) && !networkedTrainCar.HasPlayers())
             return true;
         __instance.PointToCar(null);
         return false;

--- a/Multiplayer/Patches/CommsRadio/RerailControllerPatch.cs
+++ b/Multiplayer/Patches/CommsRadio/RerailControllerPatch.cs
@@ -79,7 +79,7 @@ public static class RerailControllerPatch
         if (!Physics.Raycast(__instance.signalOrigin.position, __instance.signalOrigin.forward, out __instance.hit, RerailController.SIGNAL_RANGE, __instance.trainCarMask))
             return true;
         TrainCar car = TrainCar.Resolve(__instance.hit.transform.root);
-        if (car != null && car.IsRerailAllowed && car.TryNetworked(out NetworkedTrainCar networkedTrainCar) && !networkedTrainCar.HasPlayers)
+        if (car != null && car.IsRerailAllowed && car.TryNetworked(out NetworkedTrainCar networkedTrainCar) && !networkedTrainCar.HasPlayers())
             return true;
         __instance.PointToCar(null);
         return false;

--- a/Multiplayer/Patches/Train/CarVisitCheckerPatch.cs
+++ b/Multiplayer/Patches/Train/CarVisitCheckerPatch.cs
@@ -25,30 +25,27 @@ public static class CarVisitCheckerPatch
         }
         if (NetworkLifecycle.Instance.Server.ServerPlayers.Count == 0)
         {
-
             //no server players (this should only apply to a dedicated server), don't despawn
             __instance.playerIsInCar = true;
             __result = true;
             return false;
         }
 
+        if (!NetworkedTrainCar.TryGetFromTrainCar(__instance.car, out NetworkedTrainCar netTC))
+        {
+            //Car was not found, allow it to despawn
+            __instance.playerIsInCar = false;
+            __result = false;
+            return false;
+        }
+
         //We are the host, check all players against this car
         foreach (ServerPlayer player in NetworkLifecycle.Instance.Server.ServerPlayers)
         {
-            if (NetworkedTrainCar.TryGetFromTrainCar(__instance.car, out NetworkedTrainCar netTC))
+            if (player.CarId == netTC.NetId)
             {
-                if (player.CarId == netTC.NetId)
-                {
-                    __instance.playerIsInCar = true;
-                    __result = true;
-                    return false;
-                }
-            }
-            else
-            {
-                //Car was not found, allow it to despawn
-                __instance.playerIsInCar = false;
-                __result = false;
+                __instance.playerIsInCar = true;
+                __result = true;
                 return false;
             }
         }
@@ -70,4 +67,31 @@ public static class CarVisitCheckerPatch
         return false;
     }
     */
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(CarVisitChecker.OnPlayerCarChanged))]
+    private static bool OnPlayerCarChanged_Prefix(CarVisitChecker __instance)
+    {
+        if (!NetworkedTrainCar.TryGetFromTrainCar(__instance.car, out NetworkedTrainCar netTC) || netTC == null)
+            return true;
+
+        if (netTC.HasPlayers())
+        {
+            __instance.playerIsInCar = true;
+            __instance.recentlyVisitedTimer.StopCountdown();
+        }
+        else
+        {
+            __instance.playerIsInCar = false;
+            __instance.recentlyVisitedTimer.StartCountdown(CarVisitChecker.RECENTLY_VISITED_TIME_THRESHOLD, CarVisitChecker.COUNTDOWN_TIME_UNIT);
+
+            if (__instance.propagateToFront)
+                __instance.VisitConnectedCars(__instance.car?.frontCoupler?.coupledTo);
+
+            if (__instance.propagateToRear)
+                __instance.VisitConnectedCars(__instance.car?.rearCoupler?.coupledTo);
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
Makes Work Trains more useable (fixes #138)

Changes the conditions under which a Work Train is considered to be in use.
Resolves the issue of money being taken when the loco is in use.

New parameters for "In Use":
- Any players on the loco or any carriages/locomotives the loco is coupled to.
- The loco or any coupled carriages/locomotives are moving.
- The loco's engine or the engine of any loco in the train is running.
  - Diesel engines: engine is running.
  - Steam engines: firebox is lit.
  - Electric engines (e.g. BE2): main breaker is on.
- The loco's handbrake is not applied (handbrake only has to be very slightly on).
- The loco is part of a train and the train has a carriage with an active job.
- The loco or one of the coupled carriages/locomotives has been occupied in the last 10 mins (real time).

Per normal game play, if a work train is cleared it will be sent back to the garage/museum, the engine shut off and the handbrake fully applied. Additionally, the last occupied time will be cleared, allowing the work train to be requested immediately.